### PR TITLE
Fix re-focusing target and expose bounds object on 3.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,7 @@ export class OverlayWindow extends EventEmitter {
 
   static focusTarget () {
     OverlayWindow.#willBeFocused = 'target'
+    OverlayWindow.#electronWindow.setIgnoreMouseEvents(true)
     lib.focusTarget()
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,8 @@ export interface MoveresizeEvent {
 
 export class OverlayWindow extends EventEmitter {
   static #electronWindow: BrowserWindow
-  static #lastBounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
+  /** Exposed so that apps can get the current bounds of the target */
+  static bounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
   static #isFocused = false
   static #willBeFocused: 'overlay' | 'target' | undefined
 
@@ -75,7 +76,7 @@ export class OverlayWindow extends EventEmitter {
       if (e.isFullscreen !== undefined) {
         OverlayWindow.#electronWindow.setFullScreen(e.isFullscreen)
       }
-      OverlayWindow.#lastBounds = e
+      OverlayWindow.bounds = e
       OverlayWindow.#updateOverlayBounds()
     })
 
@@ -91,7 +92,7 @@ export class OverlayWindow extends EventEmitter {
     const dispatchMoveresize = throttle(34 /* 30fps */, OverlayWindow.#updateOverlayBounds)
 
     OverlayWindow.events.on('moveresize', (e: MoveresizeEvent) => {
-      OverlayWindow.#lastBounds = e
+      OverlayWindow.bounds = e
       dispatchMoveresize()
     })
 
@@ -119,16 +120,16 @@ export class OverlayWindow extends EventEmitter {
   }
 
   static #updateOverlayBounds () {
-    let lastBounds = OverlayWindow.#lastBounds
+    let lastBounds = OverlayWindow.bounds
     if (lastBounds.width != 0 && lastBounds.height != 0) {
       if (process.platform === 'win32') {
-        lastBounds = screen.screenToDipRect(OverlayWindow.#electronWindow, OverlayWindow.#lastBounds)
+        lastBounds = screen.screenToDipRect(OverlayWindow.#electronWindow, OverlayWindow.bounds)
       }
       OverlayWindow.#electronWindow.setBounds(lastBounds)
       if (process.platform === 'win32') {
         // if moved to screen with different DPI, 2nd call to setBounds will correctly resize window
         // dipRect must be recalculated as well
-        lastBounds = screen.screenToDipRect(OverlayWindow.#electronWindow, OverlayWindow.#lastBounds)
+        lastBounds = screen.screenToDipRect(OverlayWindow.#electronWindow, OverlayWindow.bounds)
         OverlayWindow.#electronWindow.setBounds(lastBounds)
       }
     }


### PR DESCRIPTION
# Fix re-focusing

## Motivation

I noticed that when in the demo app, after pressing Cmd + J twice, it didn't allow typing into Notepad/TextEdit again.

## Fix

Change `focusTarget` to call `electronWindow.setIgnoreMouseEvents(true)` again

## Testing

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2937410/138424408-06ab85a0-c5d8-4e47-b222-ac3af747ba4e.gif) | ![After](https://user-images.githubusercontent.com/2937410/138424438-a1824b2d-a914-4177-8520-605785acabcf.gif) |

# Expose bounds object

## Motivation

Awakened POE Trade tries to get the bounds, but it's not exposed publicly.

## Fix

Change `#lastBounds` to `bounds`

## Testing

Ran with Awakened POE Trade. It gets rid of a big full-screen error about not being able to get bounds.