### PR TITLE
Added MacOS support for 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dist
 
 build
 prebuilds
+
+# Mac storage
+.DS_Store

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,65 @@
+# Building and running code
+
+## Building for release
+
+Running `yarn prebuild` and `yarn build-ts` should build everything needed
+for release.
+
+## Testing with the demo app
+
+When developing, running `npm run demo:electron` or `yarn demo:electron`
+will build and run a demo app that's useful for testing this.
+
+## Debugging native Mac code
+
+1.  Create an XCode project by running `node-gyp configure -- -f xcode`.
+2.  Change to debug mode by running `node-gyp configure --debug`.
+    - If there is a previous debug 
+3.  Run the Electron demo by running `yarn demo:electron`
+3.  Go into XCode, open the project in `build/binding.xcodeproj`, and then use
+    the "Debug > Attach to Process" menu to attach to the Electron process.
+
+# How this library works
+
+This library largely works by hooking into the event handlers so that the
+overlay window can be moved and shown/hidden to match the target window
+that it's supposed to overlay.
+
+# Code structure
+
+The main module exposes a singleton overlayWindow that can be used to control
+the overlay.
+
+On startup:
+
+- User calls `OverlayWindow.attachTo()`
+- `attachTo` calls `lib.start()`, which corresponds to the `AddonStart`
+  function inside of addon.c
+- `AddonStart` largely delegates the platform specific code by calling
+  `ow_start_hook`, a function defined for each platform.
+
+## Native module
+
+Immediately on attaching to a window, a background thread executes
+`hook_thread` (names for Mac are in camelCase, but otherwise similar).
+
+## hook_thread
+
+`hook_thread` does the following on Windows:
+
+- Hook foreground, minimize events for all windows
+- Hook foreground window rename and call `check_and_handle_window`
+- Start the event loop
+
+## check_and_handle_window
+
+`check_and_handle_window` does the following on Windows:
+
+- Initialize `is_focused`, `is_destroyed`, and other properties on
+  `target_info`
+- Emits events for the initialization (blur, detach, focus)
+- Create hooks for window move and destroy
+  - Cleans up any existing hooks before this
+- Attaches the target's input handling to the overlay's input handling
+- Make the overlay window have the other window as a parent
+- Emit attach and focus events

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,9 +12,8 @@ will build and run a demo app that's useful for testing this.
 
 ## Debugging native Mac code
 
-1.  Create an XCode project by running `node-gyp configure -- -f xcode`.
+1.  Create an XCode project by running `node-gyp configure --debug -- -f xcode`.
 2.  Change to debug mode by running `node-gyp configure --debug`.
-    - If there is a previous debug 
 3.  Run the Electron demo by running `yarn demo:electron`
 3.  Go into XCode, open the project in `build/binding.xcodeproj`, and then use
     the "Debug > Attach to Process" menu to attach to the Electron process.
@@ -32,8 +31,8 @@ the overlay.
 
 On startup:
 
-- User calls `OverlayWindow.attachTo()`
-- `attachTo` calls `lib.start()`, which corresponds to the `AddonStart`
+- User calls `OverlayController.attachByTitle()`
+- `attachByTitle` calls `lib.start()`, which corresponds to the `AddonStart`
   function inside of addon.c
 - `AddonStart` largely delegates the platform specific code by calling
   `ow_start_hook`, a function defined for each platform.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Building for release
 
-Running `yarn prebuild` and `yarn build-ts` should build everything needed
+Running `yarn prebuild` and `yarn tsc` should build everything needed
 for release.
 
 ## Testing with the demo app
@@ -60,5 +60,4 @@ Immediately on attaching to a window, a background thread executes
 - Create hooks for window move and destroy
   - Cleans up any existing hooks before this
 - Attaches the target's input handling to the overlay's input handling
-- Make the overlay window have the other window as a parent
 - Emit attach and focus events

--- a/binding.gyp
+++ b/binding.gyp
@@ -36,7 +36,24 @@
       	  'sources': [
             'src/lib/x11.c',
           ]
-      	}]
+        }],
+        ['OS=="mac"', {
+          'link_settings': {
+            'libraries': [
+              '-lpthread', '-framework AppKit', '-framework ApplicationServices'
+            ]
+          },
+          'xcode_settings': {
+            'OTHER_CFLAGS': [
+              '-fobjc-arc'
+            ]
+          },
+          'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread'],
+          'sources': [
+            'src/lib/mac.mm',
+            'src/lib/mac/OWFullscreenObserver.mm'
+          ]
+        }]
       ]
     }
   ]

--- a/src/demo/electron-demo.ts
+++ b/src/demo/electron-demo.ts
@@ -6,6 +6,9 @@ app.disableHardwareAcceleration()
 
 let window: BrowserWindow
 
+const toggleMouseKey = 'CmdOrCtrl + J'
+const toggleShowKey = 'CmdOrCtrl + K'
+
 function createWindow () {
   window = new BrowserWindow({
     width: 400,
@@ -27,8 +30,8 @@ function createWindow () {
         <div style="padding: 16px; border-radius: 8px; background: rgb(255,255,255); border: 4px solid red; display: inline-block;">
           <span>Overlay Window</span>
           <span id="text1"></span>
-          <br><span><b>CmdOrCtrl + Q</b> to toggle setIgnoreMouseEvents</span>
-          <br><span><b>CmdOrCtrl + H</b> to "hide" overlay using CSS</span>
+          <br><span><b>${toggleMouseKey}</b> to toggle setIgnoreMouseEvents</span>
+          <br><span><b>${toggleShowKey}</b> to "hide" overlay using CSS</span>
         </div>
       </div>
       <script>
@@ -54,7 +57,11 @@ function createWindow () {
 
   makeDemoInteractive()
 
-  OverlayController.attachByTitle(window, 'Untitled - Notepad')
+  OverlayController.attachByTitle(
+    window,
+    process.platform === 'darwin' ? 'Untitled' : 'Untitled - Notepad',
+    { hasTitleBarOnMac: true }
+  )
 }
 
 function makeDemoInteractive () {
@@ -77,9 +84,9 @@ function makeDemoInteractive () {
     window.webContents.send('focus-change', false)
   })
 
-  globalShortcut.register('CmdOrCtrl + Q', toggleOverlayState)
+  globalShortcut.register(toggleMouseKey, toggleOverlayState)
 
-  globalShortcut.register('CmdOrCtrl + H', () => {
+  globalShortcut.register(toggleShowKey, () => {
     window.webContents.send('visibility-change', false)
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export interface MoveresizeEvent {
   height: number
 }
 
-export interface AttachToOptions {
+export interface AttachOptions {
   // Whether the Window has a title bar. We adjust the overlay to not cover
   // it
   hasTitleBarOnMac?: boolean
@@ -76,7 +76,7 @@ class OverlayControllerGlobal {
   private focusNext: 'overlay' | 'target' | undefined
   // The height of a title bar on a standard window. Only measured on Mac
   private macTitleBarHeight = 0
-  private attachToOptions: AttachToOptions = {}
+  private attachOptions: AttachOptions = {}
 
   readonly events = new EventEmitter()
 
@@ -216,7 +216,7 @@ class OverlayControllerGlobal {
 
   /** If we're on a Mac, adjust the bounds to not overlap the title bar */
   private adjustBoundsForMacTitleBar (bounds: Rectangle) {
-    if (!isMac || !this.attachToOptions.hasTitleBarOnMac) {
+    if (!isMac || !this.attachOptions.hasTitleBarOnMac) {
       return bounds
     }
 
@@ -240,7 +240,7 @@ class OverlayControllerGlobal {
     lib.focusTarget()
   }
 
-  attachByTitle (electronWindow: BrowserWindow, targetWindowTitle: string, options: AttachToOptions = {}) {
+  attachByTitle (electronWindow: BrowserWindow, targetWindowTitle: string, options: AttachOptions = {}) {
     if (this.electronWindow) {
       throw new Error('Library can be initialized only once.')
     } else {
@@ -257,7 +257,7 @@ class OverlayControllerGlobal {
       this.focusNext = undefined
     })
 
-    this.attachToOptions = options
+    this.attachOptions = options
     if (isMac) {
       this.calculateMacTitleBarHeight()
     }

--- a/src/lib/mac.mm
+++ b/src/lib/mac.mm
@@ -1,0 +1,638 @@
+#import "mac/OWFullscreenObserver.h"
+#include "overlay_window.h"
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <Foundation/Foundation.h>
+#import <array>
+
+/**
+ * FORMATTING: This file was formatted automatically with clang-format.
+ * We recommend formatting with clang-format before commiting updates.
+ *
+ * This file handles the overlay window for Mac. It:
+ *
+ * 1. Uses the accessibility API, creates two sets of listeners
+ *    - Listen to any window switches by attaching to the foreground app
+ *    - When it finds the targetWindow, listen to any move/resize events
+ *      by attaching to the targetWindow.
+ * 2. Sends those events back up via the standard overlay_window APIs.
+ * 3. The Javascript code only shows the overlay window when the target window
+ *    is in the foreground.
+ */
+
+extern "C" {
+/**
+ * Undocumented, but widely used API to get the Window ID
+ * See
+ * https://stackoverflow.com/questions/7422666/uniquely-identify-active-window-on-os-x
+ */
+AXError _AXUIElementGetWindow(AXUIElementRef, CGWindowID *out);
+}
+
+static void checkAndHandleWindow(pid_t pid, AXUIElementRef frontmostWindow);
+
+struct ow_target_window {
+  const char *title;
+  /** Set to -1 if not initialized yet */
+  pid_t pid;
+  /** Window matching the target title, or null */
+  AXUIElementRef element;
+  /** Observer that sends all observed events to hookProc */
+  AXObserverRef observer;
+  bool isFocused;
+  bool isDestroyed;
+  bool isFullscreen;
+};
+
+struct ow_overlay_window {
+  NSWindow *window;
+};
+
+struct ow_frontmost_app {
+  /** Set to -1 if not initialized */
+  pid_t pid;
+  /** Set to 0 if not initialized */
+  CGWindowID windowID;
+  /** Latest application (not window) identified to be frontmost */
+  AXUIElementRef element;
+  /** Observer that sends all observed events to hookProc */
+  AXObserverRef observer;
+};
+
+/**
+ * This should only be modified inside the checkAndHandleWindow
+ * function for more centralized logic.
+ */
+static struct ow_target_window targetInfo = {
+    .title = NULL,
+    .pid = -1,
+    .element = NULL,
+    .observer = NULL,
+    .isFocused = false,
+    .isFullscreen = false,
+};
+
+static struct ow_overlay_window overlayInfo = {.window = NULL};
+
+/**
+ * Unlike on Windows and Linux, we have no way to listen to all window
+ * foreground changes. As such, we have to always just check when the
+ * foreground app changes, and recheck focus/frontmost when it does.
+ */
+static struct ow_frontmost_app frontmostInfo = {
+    .pid = -1, .windowID = 0, .element = NULL, .observer = NULL};
+
+static OWFullscreenObserver *fullscreenObserver = NULL;
+
+// Window notifications: these are attached to the target window.
+// These must be handled by `hookProcTargetWindow`.
+static std::array<CFStringRef, 4> windowNotificationTypes = {
+    kAXUIElementDestroyedNotification, kAXMovedNotification,
+    kAXResizedNotification, kAXTitleChangedNotification};
+
+// Applicaton notifications: these are attached to the foreground (not
+// necessarily the target) app
+static std::array<CFStringRef, 5> appFocusNotificationTypes = {
+    kAXFocusedWindowChangedNotification, kAXApplicationDeactivatedNotification,
+    kAXApplicationHiddenNotification, kAXMainWindowChangedNotification,
+    kAXWindowMiniaturizedNotification};
+
+bool requestAccessibility(bool showDialog) {
+  NSDictionary *opts =
+      @{(__bridge id)(kAXTrustedCheckOptionPrompt) : showDialog ? @YES : @NO};
+  return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
+}
+
+/**
+ * Make sure to release the returns of all "copy" functions with CFRelease
+ * when done
+ */
+static AXUIElementRef copyFrontmostWindow(pid_t pid) {
+  AXUIElementRef appElement = AXUIElementCreateApplication(pid);
+
+  AXUIElementRef window = NULL;
+  AXError error = AXUIElementCopyAttributeValue(
+      appElement, kAXFocusedWindowAttribute, (CFTypeRef *)&window);
+  CFRelease(appElement);
+  if (error != kAXErrorSuccess) {
+    return NULL;
+  }
+
+  return window;
+}
+
+/** Gets the process ID of the current frontmost app */
+static pid_t getFrontmostAppPID() {
+  NSRunningApplication *app =
+      [[NSWorkspace sharedWorkspace] frontmostApplication];
+  return [app processIdentifier];
+}
+
+/**
+ * Equivalent to the window's windowNumber. Will be <= 0 when invalid,
+ * according to
+ * https://developer.apple.com/documentation/appkit/nswindow/1419068-windownumber?language=objc
+ */
+static CGWindowID getWindowID(AXUIElementRef window) {
+  CGWindowID windowID = 0;
+  _AXUIElementGetWindow(window, &windowID);
+  return windowID;
+}
+
+static NSString *getTitleForWindow(AXUIElementRef window) {
+  CFStringRef cfTitle = NULL;
+  AXError error = AXUIElementCopyAttributeValue(window, kAXTitleAttribute,
+                                                (CFTypeRef *)&cfTitle);
+  if (error != kAXErrorSuccess) {
+    return NULL;
+  }
+
+  NSString *title = CFBridgingRelease(cfTitle);
+  return title;
+}
+
+/**
+ * Copied from
+ * https://github.com/sentialx/node-window-manager/blob/v2.2.0/lib/macos.mm#L25
+ */
+static NSDictionary *getWindowInfo(CGWindowID windowID) {
+  NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(
+      kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+      kCGNullWindowID));
+
+  for (NSDictionary *info in windows) {
+    NSNumber *windowNumber = info[(id)kCGWindowNumber];
+    if ([windowNumber intValue] == (int)windowID) {
+      return info;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * Gets the current bounds for a `windowID`. Returns true only if we
+ * successfully wrote the bounds to `outputBounds`.
+ */
+static bool getBounds(CGWindowID windowID, ow_window_bounds *outputBounds) {
+  if (windowID <= 0) {
+    return false;
+  }
+  NSDictionary *windowInfo = getWindowInfo(windowID);
+  if (!windowInfo) {
+    return false;
+  }
+  NSDictionary *inputBounds = windowInfo[(id)kCGWindowBounds];
+  if (!inputBounds) {
+    return false;
+  }
+
+  NSNumber *x = inputBounds[@"X"];
+  NSNumber *y = inputBounds[@"Y"];
+  NSNumber *width = inputBounds[@"Width"];
+  NSNumber *height = inputBounds[@"Height"];
+
+  if (x && y && width && height) {
+    *outputBounds = {
+        .x = [x intValue],
+        .y = [y intValue],
+        .width = static_cast<uint32_t>([width intValue]),
+        .height = static_cast<uint32_t>([height intValue]),
+    };
+    return true;
+  };
+
+  return false;
+}
+
+static void emitMoveResizeEvent(CGWindowID windowID) {
+  if (!targetInfo.element) {
+    return;
+  }
+  CGWindowID targetWindowID = getWindowID(targetInfo.element);
+  if (windowID != targetWindowID) {
+    return;
+  }
+
+  struct ow_window_bounds bounds;
+  if (getBounds(windowID, &bounds)) {
+    struct ow_event e = {.type = OW_MOVERESIZE,
+                         .data.moveresize = {.bounds = bounds}};
+    ow_emit_event(&e);
+  }
+}
+
+/**
+ * Calls checkAndHandleWindow with the latest window
+ */
+static void handleFocusMaybeChanged() {
+  pid_t frontmostPID = getFrontmostAppPID();
+  AXUIElementRef frontmostWindow = copyFrontmostWindow(frontmostPID);
+
+  checkAndHandleWindow(frontmostPID, frontmostWindow);
+
+  if (frontmostWindow) {
+    CFRelease(frontmostWindow);
+  }
+}
+
+/**
+ * Handle notifications (activate, deactivate, focus change) from the
+ * frontmost application.
+ */
+static void hookProcFrontmostApplication(AXObserverRef observer,
+                                         AXUIElementRef element,
+                                         CFStringRef cfNotificationType,
+                                         void *contextData) {
+  // NSString *notificationType = (__bridge NSString *)cfNotificationType;
+  // NSLog(@"hookProcFrontmostApplication: processing for type %@",
+  //       notificationType);
+
+  handleFocusMaybeChanged();
+}
+
+/**
+ * Handle notifications (move, resize, destroy) from the target window.
+ */
+static void hookProcTargetWindow(AXObserverRef observer, AXUIElementRef element,
+                                 CFStringRef cfNotificationType,
+                                 void *contextData) {
+  NSString *notificationType = (__bridge NSString *)cfNotificationType;
+  // NSLog(@"hookProcTargetWindow: processing for type %@", notificationType);
+
+  // Handle move/resize events
+  for (auto &moveResizeNotificationType :
+       {kAXMovedNotification, kAXResizedNotification}) {
+    if ([notificationType
+            isEqualToString:(__bridge NSString *)moveResizeNotificationType]) {
+      CGWindowID windowID = getWindowID(element);
+      emitMoveResizeEvent(windowID);
+    }
+  }
+
+  // Handle destroy
+  if ([notificationType
+          isEqualToString:(__bridge NSString *)
+                              kAXUIElementDestroyedNotification]) {
+    targetInfo.isDestroyed = true;
+    handleFocusMaybeChanged();
+  }
+
+  // Handle title change
+  if ([notificationType
+          isEqualToString:(__bridge NSString *)kAXTitleChangedNotification]) {
+    NSString *title = getTitleForWindow(element);
+    if (title) {
+      targetInfo.title = [title UTF8String];
+    }
+  }
+}
+
+/**
+ * Checks whether the system is currently full-screen. From logic in this
+ * StackOverflow answer. This only works if the user only has 1 screen.
+ *
+ * https://stackoverflow.com/questions/23896803/os-x-detecting-when-front-app-goes-into-fullscreen-mode
+ */
+static bool isFullscreenFromWindows() {
+  NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(
+      kCGWindowListOptionOnScreenOnly, kCGNullWindowID));
+
+  for (NSDictionary *info in windows) {
+    // Based on logic from
+    // https://stackoverflow.com/questions/23896803/os-x-detecting-when-front-app-goes-into-fullscreen-mode
+    // In full-screen, very few windows are present. We return that it's
+    // full-screen only if no SystemUIServer windows are present.
+    if ([info[@"kCGWindowOwnerName"] isEqualToString:@"SystemUIServer"]) {
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+/**
+ * Checks whether the system is currently full-screen. This logic seems to
+ * only work once per focus, but it does work on multiple screens.
+ */
+static bool isFullscreenFromBounds(CGWindowID targetWindowID) {
+  ow_window_bounds bounds;
+  bool success = getBounds(targetWindowID, &bounds);
+
+  // The y should only be 0 if the app is fullscreen
+  return success && bounds.y == 0;
+}
+
+/**
+ * Checks whether the system is currently full-screen. This logic was
+ * determined experimentally.
+ */
+static bool isFullscreen(CGWindowID targetWindowID) {
+  return isFullscreenFromWindows() || isFullscreenFromBounds(targetWindowID);
+}
+
+/**
+ * Creates an observer for observing a set of notification types for a specific
+ * process/window combination.
+ *
+ * Most of this logic is based on code from
+ * https://stackoverflow.com/a/853953/319066
+ */
+template <std::size_t N>
+static AXObserverRef
+createObserver(pid_t pid, AXUIElementRef element,
+               std::array<CFStringRef, N> notificationTypes,
+               bool isTargetWindow) {
+  AXObserverRef observer = NULL;
+  AXError error =
+      isTargetWindow
+          ? AXObserverCreate(pid, hookProcTargetWindow, &observer)
+          : AXObserverCreate(pid, hookProcFrontmostApplication, &observer);
+  if (error != kAXErrorSuccess) {
+    return NULL;
+  }
+
+  if (element) {
+    for (auto &notificationType : notificationTypes) {
+      AXObserverAddNotification(observer, element, notificationType, NULL);
+      // NSLog(@"createObserver: created for PID %d with type %@", pid,
+      //       notificationType);
+    }
+  }
+  CFRunLoopAddSource([[NSRunLoop currentRunLoop] getCFRunLoop],
+                     AXObserverGetRunLoopSource(observer),
+                     kCFRunLoopDefaultMode);
+  return observer;
+}
+
+/**
+ * Removes an observer from the event loop and cleans up all handlers.
+ * Does not release any resources.
+ */
+template <std::size_t N>
+static void removeObserver(AXObserverRef observer, AXUIElementRef element,
+                           std::array<CFStringRef, N> notificationTypes) {
+  if (!observer) {
+    return;
+  }
+
+  CFRunLoopRemoveSource([[NSRunLoop currentRunLoop] getCFRunLoop],
+                        AXObserverGetRunLoopSource(observer),
+                        kCFRunLoopDefaultMode);
+  if (element) {
+    for (auto &notificationType : notificationTypes) {
+      AXObserverRemoveNotification(observer, element, notificationType);
+    }
+  }
+}
+
+/**
+ * Clear the `windowInfo`, making sure to release memory of associated
+ * observers for the given `notificationTypes` and the window itself.
+ */
+template <typename WindowInfo, std::size_t NotificationTypesSize>
+static void clearWindowInfo(
+    WindowInfo &windowInfo,
+    std::array<CFStringRef, NotificationTypesSize> notificationTypes) {
+  if (windowInfo.observer) {
+    removeObserver(windowInfo.observer, windowInfo.element, notificationTypes);
+    CFRelease(windowInfo.observer);
+    windowInfo.observer = NULL;
+  }
+
+  if (windowInfo.element) {
+    CFRelease(windowInfo.element);
+    windowInfo.element = NULL;
+  }
+}
+
+/**
+ * Clear and reinitialize the `windowInfo` object for the current element,
+ * including any observers for the `notificationTypes`.
+ */
+template <typename WindowInfo, std::size_t NotificationTypesSize>
+static void updateWindowInfo(
+    pid_t pid, AXUIElementRef element, WindowInfo &windowInfo,
+    std::array<CFStringRef, NotificationTypesSize> notificationTypes,
+    bool isTargetWindow) {
+  clearWindowInfo(windowInfo, notificationTypes);
+
+  windowInfo.element = element;
+  CFRetain(windowInfo.element);
+  windowInfo.observer = createObserver(pid, windowInfo.element,
+                                       notificationTypes, isTargetWindow);
+}
+
+/**
+ * For a brief while after we reattach accessibility observers to a new app,
+ * that new app may not report any events. For that amount of time, we
+ * manually poll for changes.
+ *
+ * This seems to only last for 2-3 seconds, but we poll for 5s to be safe.
+ */
+static void pollAfterAppObserverChange() {
+  NSTimeInterval secondsToPoll = 5;
+  NSTimeInterval startTime = [[NSDate date] timeIntervalSince1970];
+  [NSTimer
+      scheduledTimerWithTimeInterval:0.2
+                             repeats:YES
+                               block:^(NSTimer *timer) {
+                                 NSTimeInterval currentTime =
+                                     [[NSDate date] timeIntervalSince1970];
+                                 if (currentTime - startTime >= secondsToPoll &&
+                                     timer) {
+                                   [timer invalidate];
+                                   timer = NULL;
+                                 }
+                                 handleFocusMaybeChanged();
+                               }];
+}
+
+/**
+ * Called with the frontmost window and its PID.
+ */
+static void checkAndHandleWindow(pid_t pid, AXUIElementRef frontmostWindow) {
+  CGWindowID frontmostWindowID = getWindowID(frontmostWindow);
+  CGWindowID targetWindowID = getWindowID(targetInfo.element);
+  CGWindowID overlayWindowID =
+      overlayInfo.window ? [overlayInfo.window windowNumber] : 0;
+
+  // Emit blur/detach/focus if the frontmost window has changed
+  // We count the target as focused even if the overlay is focused, since
+  // we don't want to hide the overlay when the user is using it
+  bool targetFocused =
+      frontmostWindowID != 0 && targetWindowID == frontmostWindowID;
+
+  if (targetFocused && !targetInfo.isFocused) {
+    targetInfo.isFocused = true;
+    struct ow_event e = {.type = OW_FOCUS};
+    // NSLog(@"checkAndHandleWindow: focus");
+    ow_emit_event(&e);
+  } else if (!targetFocused && targetInfo.isFocused) {
+    if (targetInfo.isDestroyed || frontmostWindowID != overlayWindowID) {
+      targetInfo.isFocused = false;
+      struct ow_event e = {.type = OW_BLUR};
+      // NSLog(@"checkAndHandleWindow: blur");
+      ow_emit_event(&e);
+    }
+
+    if (targetInfo.isDestroyed) {
+      targetInfo.pid = -1;
+      targetInfo.isDestroyed = false;
+      struct ow_event e = {.type = OW_DETACH};
+      clearWindowInfo(targetInfo, windowNotificationTypes);
+      // NSLog(@"checkAndHandleWindow: detach");
+      ow_emit_event(&e);
+    }
+  }
+
+  // Emit fullscreen event
+  bool fullscreen = isFullscreen(targetWindowID);
+
+  if (fullscreen != targetInfo.isFullscreen) {
+    targetInfo.isFullscreen = fullscreen;
+    struct ow_event e = {.type = OW_FULLSCREEN,
+                         .data.fullscreen = {.is_fullscreen = fullscreen}};
+    // NSLog(@"checkAndHandleWindow: fullscreen %d", fullscreen ? 1 : 0);
+    ow_emit_event(&e);
+  }
+
+  frontmostInfo.windowID = frontmostWindowID;
+  // Ensure that the window focus/blur observers are attached to the foreground
+  // window at all times
+  if (pid != frontmostInfo.pid) {
+    frontmostInfo.pid = pid;
+    AXUIElementRef application = AXUIElementCreateApplication(pid);
+    updateWindowInfo(pid, application, frontmostInfo, appFocusNotificationTypes,
+                     /* isTargetWindow */ false);
+    pollAfterAppObserverChange();
+  }
+
+  // For the rest of this function, only run if the title matches
+  NSString *title = getTitleForWindow(frontmostWindow);
+  if (!title || ![title isEqualToString:@(targetInfo.title)]) {
+    return;
+  }
+
+  // The rest of the initialization/teardown logic only needs to be run
+  // if the target window has changed
+  if (targetWindowID == frontmostWindowID) {
+    return;
+  }
+
+  targetInfo.pid = pid;
+  updateWindowInfo(pid, frontmostWindow, targetInfo, windowNotificationTypes,
+                   /* isTargetWindow */ true);
+
+  // Emit the attach and focus events
+  struct ow_event e = {
+      .type = OW_ATTACH,
+      // has_access is set to -1 for undefined
+      .data.attach = {.has_access = -1, .is_fullscreen = fullscreen}};
+  bool getBoundsSuccess = getBounds(frontmostWindowID, &e.data.attach.bounds);
+  if (getBoundsSuccess) {
+    // emit OW_ATTACH
+    ow_emit_event(&e);
+    // NSLog(@"checkAndHandleWindow: attach");
+
+    targetInfo.isFocused = true;
+    e.type = OW_FOCUS;
+    // NSLog(@"checkAndHandleWindow: post-attach focus");
+    ow_emit_event(&e);
+  } else {
+    // something went wrong, did the target window die right after becoming
+    // active?
+    targetWindowID = 0;
+  }
+}
+
+/**
+ * Request the accessibility permission and sleep repeatedly until it's granted.
+ */
+static void waitUntilAccessibilityGranted() {
+  NSString *trustedCheckOptionPromptKey =
+      (__bridge NSString *)kAXTrustedCheckOptionPrompt;
+  bool trusted = AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(
+      @{trustedCheckOptionPromptKey : @YES}));
+  // NSLog(@"waitUntilAccessibilityGranted: initial %d", trusted);
+
+  while (!trusted) {
+    [NSThread sleepForTimeInterval:1.0];
+    // NSLog(@"waitUntilAccessibilityGranted: polling");
+    trusted = AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(
+        @{trustedCheckOptionPromptKey : @NO}));
+  }
+}
+
+/**
+ * Create an observer that calls `handleFocusMaybeChanged` when the
+ * app goes in/out of fullscreen. Based on code from:
+ * https://stackoverflow.com/a/23899517/319066
+ */
+static void observeFullscreen() {
+  if (fullscreenObserver) {
+    return;
+  }
+
+  NSApplication *app = [NSApplication sharedApplication];
+  fullscreenObserver = [OWFullscreenObserver alloc];
+
+  void (^onPossibleFullscreen)(void) = ^() {
+    handleFocusMaybeChanged();
+  };
+  [fullscreenObserver addBlock:onPossibleFullscreen];
+
+  // Observe full screen mode from apps setting SystemUIMode
+  // or invoking 'setPresentationOptions'
+  [app addObserver:fullscreenObserver
+        forKeyPath:@"currentSystemPresentationOptions"
+           options:NSKeyValueObservingOptionNew
+           context:NULL];
+
+  [[[NSWorkspace sharedWorkspace] notificationCenter]
+      addObserverForName:NSWorkspaceActiveSpaceDidChangeNotification
+                  object:NULL
+                   queue:NULL
+              usingBlock:^(NSNotification *note) {
+                handleFocusMaybeChanged();
+              }];
+}
+
+/**
+ * Initializes listeners for the frontmost window, and then starts the event
+ * loop.
+ */
+static void hookThread(void *_arg) {
+  observeFullscreen();
+  waitUntilAccessibilityGranted();
+  handleFocusMaybeChanged();
+
+  // Start the RunLoop so that our AXObservers added by CFRunLoopAddSource
+  // work properly
+  CFRunLoopRun();
+}
+
+void ow_start_hook(char *target_window_title, void *overlay_window_id) {
+  targetInfo.title = target_window_title;
+  // Cast to a weak pointer to avoid taking ownership of the view
+  NSView *overlayView = *(NSView * __weak *)(overlay_window_id);
+  NSWindow *overlayWindow = [overlayView window];
+  overlayInfo.window = overlayWindow;
+
+  uv_thread_create(&hook_tid, hookThread, NULL);
+}
+
+void ow_activate_overlay() {
+  [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+}
+
+void ow_focus_target() {
+  if (targetInfo.pid < 0 || !targetInfo.element) {
+    return;
+  }
+
+  AXUIElementRef app = AXUIElementCreateApplication(targetInfo.pid);
+  AXUIElementSetAttributeValue(app, kAXFrontmostAttribute, kCFBooleanTrue);
+  AXUIElementRef window = targetInfo.element;
+  AXUIElementSetAttributeValue(window, kAXMainAttribute, kCFBooleanTrue);
+}

--- a/src/lib/mac/OWFullscreenObserver.h
+++ b/src/lib/mac/OWFullscreenObserver.h
@@ -1,0 +1,25 @@
+//
+//  OWFullscreenObserver.h
+//  electronoverlaywindow
+//
+//  Thin wrapper to allow for registering an observer for when the window
+//  becomes full-screen.
+//
+//  Created by Harry Yu on 5/27/21.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void (^FullscreenBlock)(void);
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWFullscreenObserver : NSObject
+
+@property(copy) FullscreenBlock fullscreenBlock;
+
+- (void)addBlock:(FullscreenBlock)fullscreenBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/lib/mac/OWFullscreenObserver.mm
+++ b/src/lib/mac/OWFullscreenObserver.mm
@@ -1,0 +1,28 @@
+//
+//  OWFullscreenObserver.m
+//  electronoverlaywindow
+//
+//  Thin wrapper to allow for registering an observer for when the window
+//  becomes full-screen.
+//
+//  Created by Harry Yu on 5/27/21.
+//
+
+#import "OWFullscreenObserver.h"
+
+@implementation OWFullscreenObserver
+
+- (void)addBlock:(FullscreenBlock)fullscreenBlock {
+  self.fullscreenBlock = fullscreenBlock;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context {
+  if (self.fullscreenBlock) {
+    self.fullscreenBlock();
+  }
+}
+
+@end

--- a/src/lib/overlay_window.h
+++ b/src/lib/overlay_window.h
@@ -1,6 +1,10 @@
 #ifndef ADDON_SRC_OVERLAY_WINDOW_H_
 #define ADDON_SRC_OVERLAY_WINDOW_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <uv.h>
 
@@ -14,7 +18,7 @@ enum ow_event_type {
   // target window is destroyed
   OW_DETACH,
   // target window fullscreen changed
-  // only emitted on X11 backend
+  // only emitted on X11 and Mac backend
   OW_FULLSCREEN,
   // target window changed position or resized
   OW_MOVERESIZE,
@@ -55,6 +59,9 @@ struct ow_event {
 
 static uv_thread_t hook_tid;
 
+// Passed the title and a pointer to the platform-specific window ID.
+// Window ID format depends on platform, see
+// https://www.electronjs.org/docs/api/browser-window#wingetnativewindowhandle
 void ow_start_hook(char* target_window_title, void* overlay_window_id);
 
 void ow_activate_overlay();
@@ -62,5 +69,9 @@ void ow_activate_overlay();
 void ow_focus_target();
 
 void ow_emit_event(struct ow_event* event);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
## Motivation

I wanted to get awakened_poe_trade working on Mac, and this was the biggest barrier, since no binaries existed for this on Mac.

PS: thanks a lot for the great demo app! I don't think developing this would've been possible without that

## Fix

Created Mac interface for overlay_window.h - for the most part, this is structured similarly to the Windows/Linux code, with a few exceptions:

1. Mac doesn't allow windows to be attached/reparented to those of other applications, so the overlay window has to stay within the separate app. To make this not look weird, we hide the window whenever the target window isn't on top
2. Mac doesn't give a global way to listen to windows becoming the foreground window. We instead do 2 things:
   - Attach to the foreground window and detect when it gets deactivated or destroyed. When it does that, attach to the next foreground window
   - When attaching observers, we poll for 5 seconds since the observers seem to take a while to take effect

### Side changes

- Documented the general structure of the code a bit in DEVELOPING.md
- Changed the example to work with TextEdit on Mac too and changed the keyboard shortcuts to not conflict with system shortcuts (Cmd + H on Mac is hide, Cmd + Q is quit app)

## Testing

Tested by:

1. Run `yarn demo:electron`
2. Open an empty, untitled TextEdit window. If you need to change the sample window, edit `attachByTitle` in the electron-demo file to attach to a window with a different title

Tested

- Getting permission
- Blurring/focusing
- Closing the app
- Only opening the window after startup
- Keyboard shortcuts

### Resizing, focusing

![Testing](https://user-images.githubusercontent.com/2937410/119331820-a78c9500-bc3c-11eb-971b-8de4933d1800.gif)

### Fullscreen

https://user-images.githubusercontent.com/2937410/119969235-29ddc780-bf63-11eb-90d0-d80e57dbf5c5.mp4