### PR TITLE
Remove extra setIgnoreMouseEvents(false) call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,6 @@ class OverlayControllerGlobal {
 
   focusTarget () {
     this.focusNext = 'target'
-    this.electronWindow.setIgnoreMouseEvents(true)
     lib.focusTarget()
   }
 


### PR DESCRIPTION
Per a comment in #29 , this added line doesn't seem necessary, as the `this.events.on('focus'` handler should get called immediately after, which does the same thing.