### PR TITLE
Add forward mouse option on AttachOptions and use it

### DIFF
--- a/src/demo/electron-demo.ts
+++ b/src/demo/electron-demo.ts
@@ -48,6 +48,11 @@ function createWindow () {
             document.body.style.display = 'none'
           }
         });
+
+        // NOTE: this is just for demo purposes
+        document.addEventListener('mousemove', (e) => {
+          console.log(e);
+        });
       </script>
     </body>
   `)
@@ -60,8 +65,11 @@ function createWindow () {
   OverlayController.attachByTitle(
     window,
     process.platform === 'darwin' ? 'Untitled' : 'Notepad',
-    { hasTitleBarOnMac: true }
-  )
+    {
+      hasTitleBarOnMac: true,
+      needForwardMouseInput: true
+    }
+  );
 }
 
 function makeDemoInteractive () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export interface MoveresizeEvent {
 export interface AttachOptions {
   // Whether the Window has a title bar. We adjust the overlay to not cover it
   hasTitleBarOnMac?: boolean
+  needForwardMouseInput?: boolean
 }
 
 const isMac = process.platform === 'darwin'
@@ -86,7 +87,9 @@ class OverlayControllerGlobal {
     this.events.on('attach', (e: AttachEvent) => {
       this.targetHasFocus = true
       if (this.electronWindow) {
-        this.electronWindow.setIgnoreMouseEvents(true)
+        this.electronWindow.setIgnoreMouseEvents(true, {
+          forward: this.attachOptions.needForwardMouseInput
+        })
         this.electronWindow.showInactive()
         this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
       }
@@ -128,7 +131,9 @@ class OverlayControllerGlobal {
       this.targetHasFocus = true
 
       if (this.electronWindow) {
-        this.electronWindow.setIgnoreMouseEvents(true)
+        this.electronWindow.setIgnoreMouseEvents(true, {
+          forward: this.attachOptions.needForwardMouseInput,
+        })
         if (!this.electronWindow.isVisible()) {
           this.electronWindow.showInactive()
           this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
@@ -238,13 +243,17 @@ class OverlayControllerGlobal {
       throw new Error('You are using the library in tracking mode')
     }
     this.focusNext = 'overlay'
-    this.electronWindow.setIgnoreMouseEvents(false)
+    this.electronWindow.setIgnoreMouseEvents(false, {
+      forward: this.attachOptions.needForwardMouseInput,
+    });
     this.electronWindow.focus()
   }
 
   focusTarget () {
     this.focusNext = 'target'
-    this.electronWindow?.setIgnoreMouseEvents(true)
+    this.electronWindow?.setIgnoreMouseEvents(true, {
+      forward: this.attachOptions.needForwardMouseInput,
+    });
     lib.focusTarget()
   }
 


### PR DESCRIPTION
On `BrowserWindow` the function `setIgnoreMouseEvents` ([Documentation](https://www.electronjs.org/docs/latest/api/browser-window#winsetignoremouseeventsignore-options)) have an option call `forward`.

If this option is set to true, mouse movements are transmitted to chromium. 

so with this option, if the overlay is not focused, it still receives mouse movements.
This allows the JS in the overlay to capture mouse movements and actions.

