### PR TITLE
feat: Add macOS screenshot support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ class OverlayControllerGlobal {
 
   // buffer suitable for use in `nativeImage.createFromBitmap`
   screenshot (): Buffer {
-    if (process.platform !== 'win32') {
+    if (process.platform !== 'win32' && !isMac) {
       throw new Error('Not implemented on your platform.')
     }
     return lib.screenshot()

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -217,6 +217,8 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
 
 #ifdef _WIN32
   ow_screenshot(img_data, last_reported_bounds.width, last_reported_bounds.height);
+#elif __APPLE__
+  ow_screenshot(img_data, last_reported_bounds.width, last_reported_bounds.height);
 #endif
 
   return img_buffer;

--- a/src/lib/mac.mm
+++ b/src/lib/mac.mm
@@ -661,3 +661,30 @@ void ow_focus_target() {
   AXUIElementRef window = targetInfo.element;
   AXUIElementSetAttributeValue(window, kAXMainAttribute, kCFBooleanTrue);
 }
+
+
+void ow_screenshot(uint8_t* out, uint32_t width, uint32_t height) {
+  if (targetInfo.element == NULL) {
+    return;
+  }
+
+  CGWindowID windowID = getWindowID(targetInfo.element);
+  if (windowID == 0) {
+    return;
+  }
+
+  CGImageRef image = CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageBoundsIgnoreFraming);
+  if (image == NULL) {
+    return;
+  }
+
+  CGContextRef context = CGBitmapContextCreate(out, width, height, 8, width * 4, CGImageGetColorSpace(image), kCGImageAlphaPremultipliedLast);
+  if (context == NULL) {
+    CGImageRelease(image);
+    return;
+  }
+
+  CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
+  CGContextRelease(context);
+  CGImageRelease(image);
+}


### PR DESCRIPTION
Usage:

```
  const screenshotBuffer = OverlayController.screenshot();
    const screenshotImage = nativeImage.createFromBuffer(screenshotBuffer, {
      width: OverlayController.targetBounds.width,
      height: OverlayController.targetBounds.height,
    });
```

Here is a result from the demo app:
![screenshot](https://github.com/SnosMe/electron-overlay-window/assets/8675906/9914b5b7-8fa9-402c-bb06-fe516fd32e1d)

Colors are a bit off but I'm not sure why. 

