### PR TITLE
Update overlay bounds before entering fullscreen to always enter fullscreen on correct monitor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ class OverlayControllerGlobal {
       // Update bounds to match target, so that overlay enters fullscreen on correct monitor in
       // multi-monitor configurations. newBounds is true when trigger is 'attach' event, solves
       // fullscreen attach when target window us running before overlay (see issue #44, pr #45).
-      if (newBounds) {
+      if (newBounds !== undefined) {
         this.targetBounds = this.targetBounds
         this.updateOverlayBounds()
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,10 +90,10 @@ class OverlayControllerGlobal {
         this.electronWindow.showInactive()
         this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
       }
+      this.targetBounds = e
       if (e.isFullscreen !== undefined) {
         this.handleFullscreen(e.isFullscreen)
       }
-      this.targetBounds = e
       this.updateOverlayBounds()
     })
 
@@ -154,6 +154,9 @@ class OverlayControllerGlobal {
         this.updateOverlayBounds();
       }
     } else {
+      // First update bounds to match target, so that overlay enters fullscreen
+      // on correct monitor in multi-monitor configurations.
+      this.updateOverlayBounds()
       this.electronWindow.setFullScreen(isFullscreen)
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,10 +90,10 @@ class OverlayControllerGlobal {
         this.electronWindow.showInactive()
         this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
       }
-      this.targetBounds = e
       if (e.isFullscreen !== undefined) {
-        this.handleFullscreen(e.isFullscreen)
+        this.handleFullscreen(e.isFullscreen, e)
       }
+      this.targetBounds = e
       this.updateOverlayBounds()
     })
 
@@ -137,7 +137,7 @@ class OverlayControllerGlobal {
     })
   }
 
-  private async handleFullscreen(isFullscreen: boolean) {
+  private async handleFullscreen(isFullscreen: boolean, newBounds: AttachEvent | undefined = undefined) {
     if (!this.electronWindow) return
 
     if (isMac) {
@@ -154,9 +154,13 @@ class OverlayControllerGlobal {
         this.updateOverlayBounds();
       }
     } else {
-      // First update bounds to match target, so that overlay enters fullscreen
-      // on correct monitor in multi-monitor configurations.
-      this.updateOverlayBounds()
+      // Update bounds to match target, so that overlay enters fullscreen on correct monitor in
+      // multi-monitor configurations. newBounds is true when trigger is 'attach' event, solves
+      // fullscreen attach when target window us running before overlay (see issue #44, pr #45).
+      if (newBounds) {
+        this.targetBounds = this.targetBounds
+        this.updateOverlayBounds()
+      }
       this.electronWindow.setFullScreen(isFullscreen)
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ class OverlayControllerGlobal {
       // multi-monitor configurations. newBounds is true when trigger is 'attach' event, solves
       // fullscreen attach when target window us running before overlay (see issue #44, pr #45).
       if (newBounds !== undefined) {
-        this.targetBounds = this.targetBounds
+        this.targetBounds = newBounds
         this.updateOverlayBounds()
       }
       this.electronWindow.setFullScreen(isFullscreen)


### PR DESCRIPTION
Fixes #44, also just realised this may fix #16, not sure if this is the exact scenario mentioned in that issue though.

When target is in fullscreen (or windowed fullscreen on linux) the attach event will make overlay fullscreen _then_ update the bounds. If the overlay starts on second monitor this will cause overlay to fullscreen on second monitor, and the bound adjustment afterwards does nothing. This probably only happens when second monitor is on the left, as I assume electron window defaults to `x: 0, y: 0`, which would be on the leftmost monitor.

First, in attach event handler, update `this.targetBounds` before `handleFullscreen`, then in `handleFullscreen` update bounds before entering fullscreen to guarantee overlay is on the same monitor as target. 