### PR TITLE
Fix Build Issue

### DIFF
--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -210,7 +210,7 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value img_buffer;
-  uint8_t* img_data;
+  void* img_data;
   size_t size = last_reported_bounds.width * last_reported_bounds.height * 4;
   status = napi_create_buffer(env, size, &img_data, &img_buffer);
   NAPI_FATAL_IF_FAILED(status, "AddonScreenshot", "napi_create_buffer");


### PR DESCRIPTION
Hey @SnosMe uh sorry this is kinda awkward, looks like I broke something in https://github.com/SnosMe/electron-overlay-window/pull/45 - just pulled latest to my personal project and I'm getting this build error:

<img width="1313" height="668" alt="image" src="https://github.com/user-attachments/assets/b1ea19a9-3992-4849-8d54-1d43d2535f65" />

I don't write in C and I didn't touch that file so not sure exactly what the hell is going on here, Copilot says:

```
Cause:
This is likely due to a change in Node.js or Electron's N-API headers, which now enforce stricter type checking.
```

Seems to be right, as docs agree with expected type: https://nodejs.org/api/n-api.html#napi_create_buffer

I deleted and re-cloned this repo and started getting the issue here as well (guess I fixed it locally a while ago and forgot so I never committed?), changes in this PR fix those issues and I can run demo successfully after this change. 

Patching this locally fixes build in my personal project, please double check this PR though as I have never written a line of C in my life :^)