### PR TITLE
Fix positioning on linux when using non-1 scale factor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ class OverlayControllerGlobal {
     if (process.platform === 'win32') {
       lastBounds = screen.screenToDipRect(this.electronWindow, this.targetBounds)
     } else if (isLinux) {
-      // The `xcb_get_geometry_reply` can receive physical coords under KDE's XWayland.
+      // The `xcb_get_geometry` can receive physical coords under KDE's XWayland.
       // see https://github.com/SnosMe/electron-overlay-window/pull/50
       // The following code should be a no-op on native X11.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class OverlayControllerGlobal {
   private isInitialized = false
   private electronWindow?: BrowserWindow
   // Exposed so that apps can get the current bounds of the target
-  // NOTE: stores screen physical rect on Windows and linux
+  // NOTE: stores screen physical rect on Windows and XWayland
   targetBounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
   targetHasFocus = false
   private focusNext: 'overlay' | 'target' | undefined
@@ -164,21 +164,16 @@ class OverlayControllerGlobal {
     if (process.platform === 'win32') {
       lastBounds = screen.screenToDipRect(this.electronWindow, this.targetBounds)
     } else if (isLinux) {
-      // Currently, CEF lacks wayland support for scaling on these APIs, and doesn't provide screenToDipRect on linux.
-      //
-      // However, we expect X11 to always use a constant scale factor between screens, so this should be sufficient
-      // there.
-      const tl = screen.screenToDipPoint({ x: lastBounds.x, y: lastBounds.y })
-      // Best effort width/height for e.g. wayland, but may not be fully correct when windows span displays.
-      const br = screen.screenToDipPoint({ x: lastBounds.x + lastBounds.width, y: lastBounds.y + lastBounds.height })
+      // The `xcb_get_geometry_reply` can receive physical coords under KDE's XWayland.
+      // see https://github.com/SnosMe/electron-overlay-window/pull/50
+      // The following code should be a no-op on native X11.
 
-      //const oldBounds = { ...lastBounds }
-      lastBounds = { x: tl.x, y: tl.y, width: br.x - tl.x, height: br.y - tl.y }
-      //console.log(`Scaling from: ${oldBounds.width.toFixed(1)}x${oldBounds.height.toFixed(1)}\n`   +
-      //            `           @: [${oldBounds.x.toFixed(1)}, ${oldBounds.y.toFixed(1)}]\n`         +
-      //            `          to: ${lastBounds.width.toFixed(1)}x${lastBounds.height.toFixed(1)}\n` +
-      //            `           @: [${lastBounds.x.toFixed(1)}, ${lastBounds.y.toFixed(1)}],\n`      +
-      //            `       Ratio: ${(oldBounds.width/lastBounds.width).toFixed(2)}`)
+      const tl = screen.screenToDipPoint({ x: lastBounds.x, y: lastBounds.y })
+      // const br = screen.screenToDipPoint({ x: lastBounds.x + lastBounds.width, y: lastBounds.y + lastBounds.height })
+      // lastBounds = { x: tl.x, y: tl.y, width: br.x - tl.x, height: br.y - tl.y }
+
+      const logicalSize = screen.screenToDipPoint({ x: lastBounds.width, y: lastBounds.height })
+      lastBounds = { x: tl.x, y: tl.y, width: logicalSize.x, height: logicalSize.y }
     }
     this.electronWindow.setBounds(lastBounds)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class OverlayControllerGlobal {
   private isInitialized = false
   private electronWindow?: BrowserWindow
   // Exposed so that apps can get the current bounds of the target
-  // NOTE: stores screen physical rect on Windows
+  // NOTE: stores screen physical rect on Windows and linux
   targetBounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
   targetHasFocus = false
   private focusNext: 'overlay' | 'target' | undefined
@@ -163,6 +163,22 @@ class OverlayControllerGlobal {
 
     if (process.platform === 'win32') {
       lastBounds = screen.screenToDipRect(this.electronWindow, this.targetBounds)
+    } else if (isLinux) {
+      // Currently, CEF lacks wayland support for scaling on these APIs, and doesn't provide screenToDipRect on linux.
+      //
+      // However, we expect X11 to always use a constant scale factor between screens, so this should be sufficient
+      // there.
+      const tl = screen.screenToDipPoint({ x: lastBounds.x, y: lastBounds.y })
+      // Best effort width/height for e.g. wayland, but may not be fully correct when windows span displays.
+      const br = screen.screenToDipPoint({ x: lastBounds.x + lastBounds.width, y: lastBounds.y + lastBounds.height })
+
+      //const oldBounds = { ...lastBounds }
+      lastBounds = { x: tl.x, y: tl.y, width: br.x - tl.x, height: br.y - tl.y }
+      //console.log(`Scaling from: ${oldBounds.width.toFixed(1)}x${oldBounds.height.toFixed(1)}\n`   +
+      //            `           @: [${oldBounds.x.toFixed(1)}, ${oldBounds.y.toFixed(1)}]\n`         +
+      //            `          to: ${lastBounds.width.toFixed(1)}x${lastBounds.height.toFixed(1)}\n` +
+      //            `           @: [${lastBounds.x.toFixed(1)}, ${lastBounds.y.toFixed(1)}],\n`      +
+      //            `       Ratio: ${(oldBounds.width/lastBounds.width).toFixed(2)}`)
     }
     this.electronWindow.setBounds(lastBounds)
 


### PR DESCRIPTION
Awakened PoE Trade gets the wrong window bounds in KDE 6.6 when scaling is active.  This can be worked around with `--force-device-scale-factor=1`, but this also creates unscaled UI in the app.

screenToDipRect is not supported on linux, though screenToDipPoint is.  In my testing with mixed-scaling displays, just translating via Point is always correct, including on e.g. overlapping monitors of different values.  I suspect this is due to multi-screen coordinates being implemented more transparently on linux, but I didn't dig further.

Tested on KDE when forcing X11 via `XDG_SESSION_TYPE=x11 ./awakened-poe-trade --ozone-platform=x11`