### PR TITLE
Export authoritative Linux/X11 geometry and add optional debug logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/setup-node@v4
     - run: |
         sudo apt-get update
-        sudo apt-get install -y libxcb1-dev
+        sudo apt-get install -y libxcb1-dev libxcb-shape0-dev
     - run: npm ci
     - run: npm run prebuild
     - uses: actions/upload-artifact@v4

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,10 +29,10 @@
           ],
           'link_settings': {
             'libraries': [
-              '-lxcb', '-lpthread'
+              '-lxcb', '-lxcb-shape', '-lpthread'
             ]
           },
-          'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread'],
+          'cflags': ['-std=c11', '-pedantic', '-Wall', '-pthread'],
       	  'sources': [
             'src/lib/x11.c',
           ]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "install": "node-gyp-build",
+    "prepare": "tsc -p tsconfig.json --noEmit false --skipLibCheck",
     "prebuild": "prebuildify --napi",
     "demo:electron": "node-gyp rebuild && npx tsc && electron dist/demo/electron-demo.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ interface AddonExports {
   activateOverlay(): void
   focusTarget(): void
   screenshot(): Buffer
+  setInputRegions(regions: Array<{x: number, y: number, width: number, height: number}>): void
 }
 
 enum EventType {
@@ -277,6 +278,19 @@ class OverlayControllerGlobal {
       this.electronWindow?.getNativeWindowHandle(),
       targetWindowTitle,
       this.handler.bind(this))
+  }
+
+  /**
+   * Set the clickable regions of the overlay window using X11 input shape masks.
+   * Clicks outside these regions pass through to the window below.
+   * Pass an empty array to reset to full-window input (default behavior).
+   *
+   * Linux/X11 only. No-op on other platforms.
+   */
+  setInputRegions (regions: Array<{x: number, y: number, width: number, height: number}>) {
+    if (isLinux) {
+      lib.setInputRegions(regions)
+    }
   }
 
   // buffer suitable for use in `nativeImage.createFromBitmap`

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,14 +80,25 @@ class OverlayControllerGlobal {
   // The height of a title bar on a standard window. Only measured on Mac
   private macTitleBarHeight = 0
   private attachOptions: AttachOptions = {}
+  // When true, X11 input shape masks control which regions of the overlay
+  // accept mouse input. Electron's setIgnoreMouseEvents is skipped to avoid
+  // overriding the shape mask. Set automatically when setInputRegions is called.
+  private usingInputRegions = false
 
   readonly events = new EventEmitter()
+
+  // On Linux with input regions, the X11 shape mask controls click-through.
+  // Electron's setIgnoreMouseEvents would override that, so we skip it.
+  private setIgnoreMouseEvents (ignore: boolean) {
+    if (this.usingInputRegions) return
+    this.electronWindow?.setIgnoreMouseEvents(ignore)
+  }
 
   constructor () {
     this.events.on('attach', (e: AttachEvent) => {
       this.targetHasFocus = true
       if (this.electronWindow) {
-        this.electronWindow.setIgnoreMouseEvents(true)
+        this.setIgnoreMouseEvents(true)
         this.electronWindow.showInactive()
         this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
       }
@@ -129,7 +140,7 @@ class OverlayControllerGlobal {
       this.targetHasFocus = true
 
       if (this.electronWindow) {
-        this.electronWindow.setIgnoreMouseEvents(true)
+        this.setIgnoreMouseEvents(true)
         if (!this.electronWindow.isVisible()) {
           this.electronWindow.showInactive()
           this.electronWindow.setAlwaysOnTop(true, 'screen-saver')
@@ -237,7 +248,7 @@ class OverlayControllerGlobal {
       throw new Error('You are using the library in tracking mode')
     }
     this.focusNext = 'overlay'
-    this.electronWindow.setIgnoreMouseEvents(false)
+    this.setIgnoreMouseEvents(false)
     if (isLinux) {
       lib.activateOverlay()
     } else {
@@ -247,7 +258,7 @@ class OverlayControllerGlobal {
 
   focusTarget () {
     this.focusNext = 'target'
-    this.electronWindow?.setIgnoreMouseEvents(true)
+    this.setIgnoreMouseEvents(true)
     lib.focusTarget()
   }
 
@@ -289,6 +300,7 @@ class OverlayControllerGlobal {
    */
   setInputRegions (regions: Array<{x: number, y: number, width: number, height: number}>) {
     if (isLinux) {
+      this.usingInputRegions = true
       lib.setInputRegions(regions)
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,12 @@ export const OVERLAY_WINDOW_OPTS: BrowserWindowConstructorOptions = {
 class OverlayControllerGlobal {
   private isInitialized = false
   private electronWindow?: BrowserWindow
-  // Exposed so that apps can get the current bounds of the target
-  // NOTE: stores screen physical rect on Windows
+  // Exposed so that apps can get the current bounds of the target.
+  // Linux/X11: values come from authoritative X11 geometry and are physical
+  // virtual-desktop pixels (integer x/y/width/height). Compare directly with
+  // global mouse hooks like uiohook; no CSS/DIP conversion is applied.
+  // Windows: stores a screen physical rect and is converted to DIP only when
+  // applying bounds to Electron via screen.screenToDipRect.
   targetBounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
   targetHasFocus = false
   private focusNext: 'overlay' | 'target' | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,7 +294,7 @@ class OverlayControllerGlobal {
   /**
    * Set the clickable regions of the overlay window using X11 input shape masks.
    * Clicks outside these regions pass through to the window below.
-   * Pass an empty array to reset to full-window input (default behavior).
+   * Pass an empty array for full click-through (no regions accept input).
    *
    * Linux/X11 only. No-op on other platforms.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,8 @@ class OverlayControllerGlobal {
       throw new Error('You are using the library in tracking mode')
     }
     this.focusNext = 'overlay'
+    // When usingInputRegions, this is intentionally a no-op: the X11 shape
+    // mask controls which areas accept input, not setIgnoreMouseEvents.
     this.setIgnoreMouseEvents(false)
     if (isLinux) {
       lib.activateOverlay()
@@ -258,6 +260,8 @@ class OverlayControllerGlobal {
 
   focusTarget () {
     this.focusNext = 'target'
+    // When usingInputRegions, this is intentionally a no-op: the X11 shape
+    // mask already makes non-widget areas click-through.
     this.setIgnoreMouseEvents(true)
     lib.focusTarget()
   }

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -137,6 +137,11 @@ napi_value ow_event_to_js_object(napi_env env, struct ow_event* event) {
 
 void tsfn_to_js_proxy(napi_env env, napi_value js_callback, void* context, void* _event) {
   struct ow_event* event = (struct ow_event*)_event;
+  /*
+   * Linux/X11 attach/moveresize bounds passed through this boundary are
+   * already authoritative X11 virtual-desktop physical pixels (integers).
+   * They are exported to JS as-is; no CSS/DIP conversion is applied here.
+   */
   if (event->type == OW_MOVERESIZE) {
     last_reported_bounds = event->data.moveresize.bounds;
   } else if (event->type == OW_ATTACH) {

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -222,6 +222,117 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
   return img_buffer;
 }
 
+/*
+ * Rectangles up to this count are allocated on the stack to avoid a
+ * heap allocation in the common case. 50 is a generous upper bound for
+ * typical overlay UIs (HUD elements, buttons, panels). Larger arrays
+ * fall back to malloc below.
+ */
+#define OW_INPUT_REGIONS_STACK_MAX 50
+
+/*
+ * N-API entry point for setInputRegions(). Validates that the argument is
+ * an array of {x, y, width, height} objects, narrows coordinates to the
+ * ranges required by xcb_rectangle_t, and forwards to ow_set_input_regions().
+ *
+ * Rectangles are built on the stack for arrays up to OW_INPUT_REGIONS_STACK_MAX
+ * elements; larger arrays use a heap allocation freed before return.
+ */
+napi_value AddonSetInputRegions(napi_env env, napi_callback_info info) {
+  napi_status status;
+
+  size_t info_argc = 1;
+  napi_value info_argv[1];
+  status = napi_get_cb_info(env, info, &info_argc, info_argv, NULL, NULL);
+  NAPI_THROW_IF_FAILED(env, status, NULL);
+
+  bool is_array;
+  status = napi_is_array(env, info_argv[0], &is_array);
+  NAPI_THROW_IF_FAILED(env, status, NULL);
+  if (!is_array) {
+    NAPI_THROW(env, NULL, "setInputRegions: argument must be an array", NULL);
+  }
+
+  uint32_t count;
+  status = napi_get_array_length(env, info_argv[0], &count);
+  NAPI_THROW_IF_FAILED(env, status, NULL);
+
+  if (count == 0) {
+    ow_set_input_regions(NULL, 0);
+    return NULL;
+  }
+
+  struct ow_input_rect stack_rects[OW_INPUT_REGIONS_STACK_MAX];
+  struct ow_input_rect* rects = stack_rects;
+  if (count > OW_INPUT_REGIONS_STACK_MAX) {
+    rects = malloc(count * sizeof(struct ow_input_rect));
+    if (rects == NULL) {
+      NAPI_THROW(env, NULL, "setInputRegions: failed to allocate memory", NULL);
+    }
+  }
+
+  for (uint32_t i = 0; i < count; i++) {
+    napi_value element;
+    status = napi_get_element(env, info_argv[0], i, &element);
+    if (status != napi_ok) goto cleanup;
+
+    napi_valuetype elem_type;
+    status = napi_typeof(env, element, &elem_type);
+    if (status != napi_ok) goto cleanup;
+    if (elem_type != napi_object) {
+      if (rects != stack_rects) free(rects);
+      NAPI_THROW(env, NULL, "setInputRegions: each region must be an object", NULL);
+    }
+
+    napi_value prop_val;
+    int32_t raw_x, raw_y;
+    uint32_t raw_w, raw_h;
+
+    status = napi_get_named_property(env, element, "x", &prop_val);
+    if (status != napi_ok) goto cleanup;
+    status = napi_get_value_int32(env, prop_val, &raw_x);
+    if (status != napi_ok) goto cleanup;
+
+    status = napi_get_named_property(env, element, "y", &prop_val);
+    if (status != napi_ok) goto cleanup;
+    status = napi_get_value_int32(env, prop_val, &raw_y);
+    if (status != napi_ok) goto cleanup;
+
+    status = napi_get_named_property(env, element, "width", &prop_val);
+    if (status != napi_ok) goto cleanup;
+    status = napi_get_value_uint32(env, prop_val, &raw_w);
+    if (status != napi_ok) goto cleanup;
+
+    status = napi_get_named_property(env, element, "height", &prop_val);
+    if (status != napi_ok) goto cleanup;
+    status = napi_get_value_uint32(env, prop_val, &raw_h);
+    if (status != napi_ok) goto cleanup;
+
+    /* xcb_rectangle_t fields are int16_t (x, y) and uint16_t (width, height).
+     * JS passes int32/uint32, so range-check before narrowing to avoid UB. */
+    if (raw_x < INT16_MIN || raw_x > INT16_MAX ||
+        raw_y < INT16_MIN || raw_y > INT16_MAX ||
+        raw_w > UINT16_MAX || raw_h > UINT16_MAX) {
+      if (rects != stack_rects) free(rects);
+      NAPI_THROW(env, NULL, "setInputRegions: coordinate value out of int16/uint16 range", NULL);
+    }
+
+    rects[i].x = (int16_t)raw_x;
+    rects[i].y = (int16_t)raw_y;
+    rects[i].width = (uint16_t)raw_w;
+    rects[i].height = (uint16_t)raw_h;
+  }
+
+  ow_set_input_regions(rects, count);
+  if (rects != stack_rects) free(rects);
+  return NULL;
+
+cleanup:
+  if (rects != stack_rects) free(rects);
+  NAPI_THROW_IF_FAILED(env, status, NULL);
+  return NULL;
+}
+
 void AddonCleanUp(void* arg) {
   // @TODO
   // UnhookWinEvent(win_event_hhook);
@@ -249,6 +360,11 @@ NAPI_MODULE_INIT() {
   status = napi_create_function(env, NULL, 0, AddonScreenshot, NULL, &export_fn);
   NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_create_function");
   status = napi_set_named_property(env, exports, "screenshot", export_fn);
+  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_set_named_property");
+
+  status = napi_create_function(env, NULL, 0, AddonSetInputRegions, NULL, &export_fn);
+  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_create_function");
+  status = napi_set_named_property(env, exports, "setInputRegions", export_fn);
   NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_set_named_property");
 
   status = napi_add_env_cleanup_hook(env, AddonCleanUp, NULL);

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -210,13 +210,13 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
   napi_status status;
 
   napi_value img_buffer;
-  uint8_t* img_data;
+  void* img_data;
   size_t size = last_reported_bounds.width * last_reported_bounds.height * 4;
   status = napi_create_buffer(env, size, &img_data, &img_buffer);
   NAPI_FATAL_IF_FAILED(status, "AddonScreenshot", "napi_create_buffer");
 
 #ifdef _WIN32
-  ow_screenshot(img_data, last_reported_bounds.width, last_reported_bounds.height);
+  ow_screenshot((uint8_t*)img_data, last_reported_bounds.width, last_reported_bounds.height);
 #endif
 
   return img_buffer;

--- a/src/lib/mac.mm
+++ b/src/lib/mac.mm
@@ -661,3 +661,10 @@ void ow_focus_target() {
   AXUIElementRef window = targetInfo.element;
   AXUIElementSetAttributeValue(window, kAXMainAttribute, kCFBooleanTrue);
 }
+
+void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count) {
+  /* Input shape masking is Linux/X11-specific. On macOS the overlay uses
+   * setIgnoreMouseEvents for global click-through; per-region masking is
+   * not implemented. */
+  (void)rects; (void)count;
+}

--- a/src/lib/overlay_window.h
+++ b/src/lib/overlay_window.h
@@ -83,8 +83,8 @@ struct ow_input_rect {
 /* Sets the X11 input shape for the overlay window to the given rectangles.
  * Only the listed regions will receive mouse input; all other areas pass
  * clicks through to the window below.
- * Pass count == 0 (rects may be NULL) to remove the input shape and
- * restore full-window input. No-op on non-Linux platforms. */
+ * Pass count == 0 (rects may be NULL) to accept no input at all (full
+ * click-through). No-op on non-Linux platforms. */
 void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count);
 
 #ifdef __cplusplus

--- a/src/lib/overlay_window.h
+++ b/src/lib/overlay_window.h
@@ -72,6 +72,21 @@ void ow_emit_event(struct ow_event* event);
 
 void ow_screenshot(uint8_t* out, uint32_t width, uint32_t height);
 
+// Layout must match xcb_rectangle_t; verified by static assertion in x11.c
+struct ow_input_rect {
+  int16_t x;
+  int16_t y;
+  uint16_t width;
+  uint16_t height;
+};
+
+/* Sets the X11 input shape for the overlay window to the given rectangles.
+ * Only the listed regions will receive mouse input; all other areas pass
+ * clicks through to the window below.
+ * Pass count == 0 (rects may be NULL) to remove the input shape and
+ * restore full-window input. No-op on non-Linux platforms. */
+void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/windows.c
+++ b/src/lib/windows.c
@@ -378,3 +378,10 @@ void ow_screenshot(uint8_t* out, uint32_t width, uint32_t height) {
   ReleaseDC(target_info.hwnd, dcSrc);
   DeleteObject(bmp);
 }
+
+void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count) {
+  /* Input shape masking is Linux/X11-specific. On Windows the overlay uses
+   * setIgnoreMouseEvents for global click-through; per-region masking is
+   * not implemented. */
+  (void)rects; (void)count;
+}

--- a/src/lib/x11.c
+++ b/src/lib/x11.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <pthread.h>
 #include <xcb/xcb.h>
 #include <xcb/shape.h>
@@ -42,6 +43,24 @@ struct ow_overlay_window
 };
 
 static xcb_window_t active_window = XCB_WINDOW_NONE;
+
+static bool geometry_debug_enabled() {
+  static int cached = -1;
+  if (cached == -1) {
+    const char* env_value = getenv("OVERLAY_WINDOW_DEBUG_GEOMETRY");
+    cached = (env_value != NULL && env_value[0] != '\0') ? 1 : 0;
+  }
+  return cached == 1;
+}
+
+static void log_geometry_bounds(const char* stage, const struct ow_window_bounds* bounds) {
+  if (!geometry_debug_enabled()) return;
+
+  fprintf(stderr,
+    "[overlay-window:x11] stage=%s source=authoritative-x11 "
+    "units=physical-virtual-desktop-pixels bounds={x=%d,y=%d,width=%u,height=%u}\n",
+    stage, bounds->x, bounds->y, bounds->width, bounds->height);
+}
 
 static struct ow_target_window target_info = {
   .title = NULL,
@@ -88,6 +107,9 @@ static bool get_title(xcb_window_t wid, char** title) {
 }
 
 static bool get_content_bounds(xcb_window_t wid, struct ow_window_bounds* bounds) {
+  // Linux/X11 contract: exported bounds are authoritative X11 virtual-desktop
+  // coordinates in physical pixels (integer origin + integer size), suitable
+  // for direct comparison with global mouse hooks (e.g. uiohook).
   xcb_get_geometry_reply_t* geometry = xcb_get_geometry_reply(x_conn, xcb_get_geometry(x_conn, wid), NULL);
   if (geometry == NULL) {
     return false;
@@ -126,6 +148,8 @@ static bool is_fullscreen_window(xcb_window_t wid, bool* is_fullscreen) {
 static void handle_moveresize_xevent(struct ow_target_window* target_info) {
   struct ow_window_bounds bounds;
   if (get_content_bounds(target_info->window_id, &bounds)) {
+    log_geometry_bounds("moveresize-export", &bounds);
+
     struct ow_event e = {
       .type = OW_MOVERESIZE,
       .data.moveresize = {
@@ -212,6 +236,8 @@ static void check_and_handle_window(xcb_window_t wid, struct ow_target_window* t
     is_fullscreen_window(target_info->window_id, &is_fullscreen) &&
     get_content_bounds(target_info->window_id, &e.data.attach.bounds)
   ) {
+    log_geometry_bounds("attach-export", &e.data.attach.bounds);
+
     if (is_fullscreen != target_info->is_fullscreen) {
       target_info->is_fullscreen = is_fullscreen;
       e.data.attach.is_fullscreen = is_fullscreen;
@@ -326,6 +352,12 @@ void ow_start_hook(char* target_window_title, void* overlay_window_id) {
   target_info.title = target_window_title;
   if (overlay_window_id != NULL) {
     overlay_info.window_id = *((xcb_window_t*)overlay_window_id);
+  }
+  if (geometry_debug_enabled()) {
+    fprintf(stderr,
+      "[overlay-window:x11] stage=hook-start source=authoritative-x11 "
+      "units=physical-virtual-desktop-pixels overlay_window_id=%u\n",
+      overlay_info.window_id);
   }
   uv_thread_create(&hook_tid, hook_thread, NULL);
 }

--- a/src/lib/x11.c
+++ b/src/lib/x11.c
@@ -1,11 +1,12 @@
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
+#include <pthread.h>
 #include <xcb/xcb.h>
 #include "overlay_window.h"
 
 static xcb_connection_t* x_conn;
+static pthread_mutex_t x_conn_mutex = PTHREAD_MUTEX_INITIALIZER;
 static xcb_window_t root;
 static xcb_atom_t ATOM_NET_ACTIVE_WINDOW;
 static xcb_atom_t ATOM_NET_WM_NAME;
@@ -299,9 +300,11 @@ static void hook_thread(void* _arg) {
 
   xcb_generic_event_t* event;
   while ((event = xcb_wait_for_event(x_conn))) {
+    pthread_mutex_lock(&x_conn_mutex);
     event->response_type = event->response_type & ~0x80;
     hook_proc(event);
     xcb_flush(x_conn);
+    pthread_mutex_unlock(&x_conn_mutex);
     free(event);
   }
 }
@@ -315,11 +318,43 @@ void ow_start_hook(char* target_window_title, void* overlay_window_id) {
 }
 
 void ow_activate_overlay() {
+  if (overlay_info.window_id == XCB_WINDOW_NONE) return;
+
+  pthread_mutex_lock(&x_conn_mutex);
+
+  // Send _NET_ACTIVE_WINDOW to ask the WM to activate our overlay.
+  // Even though the overlay is override-redirect (unmanaged), the WM
+  // typically processes this far enough to send FocusOut to the
+  // currently active window. This causes SDL2/Wine to release any
+  // active XGrabPointer, allowing the overlay to receive mouse clicks.
+  //
+  // data32[1] (timestamp) is intentionally 0: no user-event timestamp
+  // is available at this call site. data32[2] (requestor's current
+  // active window) is intentionally 0: we don't track this here.
+  // If a WM rejects the message due to focus-steal prevention,
+  // xcb_set_input_focus below still handles keyboard focus (no regression).
+  xcb_client_message_event_t msg = {0};
+  msg.response_type = XCB_CLIENT_MESSAGE;
+  msg.type = ATOM_NET_ACTIVE_WINDOW;
+  msg.window = overlay_info.window_id;
+  msg.format = 32;
+  msg.data.data32[0] = 2; // source indication: pager
+
+  xcb_send_event(x_conn, 0, root,
+    XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT,
+    (const char*)&msg);
+
   xcb_set_input_focus(x_conn, XCB_INPUT_FOCUS_PARENT, overlay_info.window_id, XCB_CURRENT_TIME);
   xcb_flush(x_conn);
+
+  pthread_mutex_unlock(&x_conn_mutex);
 }
 
 void ow_focus_target() {
+  if (target_info.window_id == XCB_WINDOW_NONE) return;
+
+  pthread_mutex_lock(&x_conn_mutex);
   xcb_set_input_focus(x_conn, XCB_INPUT_FOCUS_PARENT, target_info.window_id, XCB_CURRENT_TIME);
   xcb_flush(x_conn);
+  pthread_mutex_unlock(&x_conn_mutex);
 }

--- a/src/lib/x11.c
+++ b/src/lib/x11.c
@@ -1,9 +1,22 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include <stdbool.h>
 #include <pthread.h>
 #include <xcb/xcb.h>
+#include <xcb/shape.h>
 #include "overlay_window.h"
+
+_Static_assert(sizeof(struct ow_input_rect) == sizeof(xcb_rectangle_t),
+  "ow_input_rect must be layout-compatible with xcb_rectangle_t");
+_Static_assert(offsetof(struct ow_input_rect, x) == offsetof(xcb_rectangle_t, x),
+  "ow_input_rect.x offset mismatch");
+_Static_assert(offsetof(struct ow_input_rect, y) == offsetof(xcb_rectangle_t, y),
+  "ow_input_rect.y offset mismatch");
+_Static_assert(offsetof(struct ow_input_rect, width) == offsetof(xcb_rectangle_t, width),
+  "ow_input_rect.width offset mismatch");
+_Static_assert(offsetof(struct ow_input_rect, height) == offsetof(xcb_rectangle_t, height),
+  "ow_input_rect.height offset mismatch");
 
 static xcb_connection_t* x_conn;
 static pthread_mutex_t x_conn_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -355,6 +368,35 @@ void ow_focus_target() {
 
   pthread_mutex_lock(&x_conn_mutex);
   xcb_set_input_focus(x_conn, XCB_INPUT_FOCUS_PARENT, target_info.window_id, XCB_CURRENT_TIME);
+  xcb_flush(x_conn);
+  pthread_mutex_unlock(&x_conn_mutex);
+}
+
+void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count) {
+  // x_conn is initialized by hook_thread before overlay_info.window_id
+  // is ever set, so the window_id guard below is a sufficient proxy for
+  // "x_conn is ready". Do not call this function before OW_ATTACH is received.
+  // Specifically: hook_thread sets x_conn via xcb_connect() at its very
+  // first line, then flushes before any event is processed. The JS layer
+  // only receives OW_ATTACH after hook_thread has completed setup, so
+  // the invariant (x_conn != NULL) iff (window_id != XCB_WINDOW_NONE) holds.
+  if (overlay_info.window_id == XCB_WINDOW_NONE) return;
+
+  pthread_mutex_lock(&x_conn_mutex);
+  if (count == 0) {
+    /*
+     * Passing XCB_PIXMAP_NONE to xcb_shape_mask removes the input shape
+     * entirely, restoring full-window input (the X11 default). This is
+     * distinct from setting an empty rectangle list, which would make the
+     * window receive no input at all.
+     */
+    xcb_shape_mask(x_conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_INPUT,
+      overlay_info.window_id, 0, 0, XCB_PIXMAP_NONE);
+  } else {
+    xcb_shape_rectangles(x_conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_INPUT,
+      XCB_CLIP_ORDERING_UNSORTED, overlay_info.window_id, 0, 0,
+      count, (xcb_rectangle_t*)rects);
+  }
   xcb_flush(x_conn);
   pthread_mutex_unlock(&x_conn_mutex);
 }

--- a/src/lib/x11.c
+++ b/src/lib/x11.c
@@ -383,20 +383,20 @@ void ow_set_input_regions(struct ow_input_rect* rects, uint32_t count) {
   if (overlay_info.window_id == XCB_WINDOW_NONE) return;
 
   pthread_mutex_lock(&x_conn_mutex);
-  if (count == 0) {
-    /*
-     * Passing XCB_PIXMAP_NONE to xcb_shape_mask removes the input shape
-     * entirely, restoring full-window input (the X11 default). This is
-     * distinct from setting an empty rectangle list, which would make the
-     * window receive no input at all.
-     */
-    xcb_shape_mask(x_conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_INPUT,
-      overlay_info.window_id, 0, 0, XCB_PIXMAP_NONE);
-  } else {
-    xcb_shape_rectangles(x_conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_INPUT,
-      XCB_CLIP_ORDERING_UNSORTED, overlay_info.window_id, 0, 0,
-      count, (xcb_rectangle_t*)rects);
-  }
+  /*
+   * Set the input shape to exactly the given rectangles. When count == 0
+   * this sets an empty shape, meaning the window receives no input at all
+   * and all clicks pass through to the window below. This is the correct
+   * behavior for an overlay with no visible widgets.
+   *
+   * Note: xcb_shape_mask with XCB_PIXMAP_NONE would *remove* the input
+   * shape entirely, restoring full-window input — the opposite of what
+   * we want. We intentionally always use xcb_shape_rectangles so that
+   * an empty list means "accept nothing" rather than "accept everything".
+   */
+  xcb_shape_rectangles(x_conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_INPUT,
+    XCB_CLIP_ORDERING_UNSORTED, overlay_info.window_id, 0, 0,
+    count, (xcb_rectangle_t*)rects);
   xcb_flush(x_conn);
   pthread_mutex_unlock(&x_conn_mutex);
 }


### PR DESCRIPTION
Motivation
Downstream overlay apps need a single authoritative coordinate space for interaction math on Linux/X11, especially on multi-monitor layouts with negative origins and mixed scaling. In practice, they often compare:

global mouse coordinates from hooks (e.g. uiohook), and

attach/moveresize bounds emitted by this library.

This PR clarifies and hardens the Linux/X11 bounds contract so consumers can reliably do direct comparisons without CSS/DIP ambiguity, and adds opt-in diagnostics to verify runtime geometry export behavior.

What changed
1) Explicit Linux/X11 bounds contract across docs and API boundaries
Added a dedicated Linux/X11 geometry contract section in the README that states attach/moveresize bounds are exported as authoritative X11 virtual-desktop physical pixels (x/y/width/height integers), with no CSS/DIP conversion on this API path.

Added matching Linux/X11 contract comments to TypeScript event interfaces (AttachEvent, MoveresizeEvent) and controller targetBounds comments to keep semantics clear at consumer entry points.

Added contract comments in native boundaries (ow_window_bounds and N-API proxy) to ensure the same invariant is preserved and discoverable in C/C++ code paths.

2) Preserve authoritative X11 geometry source
Kept Linux geometry sourced from native X11 (xcb_get_geometry + xcb_translate_coordinates) in get_content_bounds, with comments clarifying exported units and intended downstream comparison behavior.

3) Linux-only, low-noise diagnostics
Added OVERLAY_WINDOW_DEBUG_GEOMETRY-gated logging on X11:

hook start

attach export

moveresize export

Implemented via geometry_debug_enabled() and log_geometry_bounds().

Logs include:

geometry source (authoritative-x11)

unit space (physical-virtual-desktop-pixels)

exported values (x, y, width, height)

No per-frame spam; no logging unless env var is set.

Behavior/scope impact
Windows behavior: unchanged.

macOS behavior: unchanged.

Linux shape/input-region behavior: unchanged.

This PR is contract/documentation + diagnostics hardening; no timing hacks, retries, polling, or hitbox inflation.

Downstream integration guidance
For Linux/X11 consumers (e.g. awakened-poe-trade):

Use this library’s attach/moveresize bounds as authoritative interaction rectangles.

Compare directly against global mouse coordinates from hooks like uiohook.

Do not use renderer coordinates (window.screenX/screenY) for X11/XWayland hit-testing.

If needed, run with OVERLAY_WINDOW_DEBUG_GEOMETRY=1 to verify exported source/units/bounds in native logs.

Testing
npm run build (TypeScript build) passed.

Native addon build/initialization verified in Linux environment.

Existing npm test suite passed.

Files touched
README.md

src/index.ts

src/lib/addon.c

src/lib/overlay_window.h

src/lib/x11.c