### PR TITLE
fix: cast to void** to fix build error with GCC 14

### DIFF
--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -212,7 +212,7 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
   napi_value img_buffer;
   uint8_t* img_data;
   size_t size = last_reported_bounds.width * last_reported_bounds.height * 4;
-  status = napi_create_buffer(env, size, &img_data, &img_buffer);
+  status = napi_create_buffer(env, size, (void **)&img_data, &img_buffer);
   NAPI_FATAL_IF_FAILED(status, "AddonScreenshot", "napi_create_buffer");
 
 #ifdef _WIN32


### PR DESCRIPTION
GCC 14 promoted `-Wincompatible-pointer-types` from a warning to a hard error. This breaks the build of the native addon on any distro shipping GCC 14+, including Arch Linux, Fedora 40+, and Ubuntu 24.10+.

Error:

```
src/lib/addon.c:215:42: error: passing argument 3 of 'napi_create_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
  215 |   status = napi_create_buffer(env, size, &img_data, &img_buffer);
      |                                          ^~~~~~~~~
      |                                          uint8_t ** {aka unsigned char **}
note: expected 'void **' but argument is of type 'uint8_t **'
```

Fix:

`napi_create_buffer` expects `void**` for the data parameter. `img_data` is `uint8_t*`, so `&img_data` is `uint8_t**`. Adding an explicit cast to (void**) satisfies GCC 14 without changing behaviour.