### PR TITLE
Add KDE Plasma Wayland support for target-window tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@ Important notes:
   - Found target window remains "valid" even if its title has changed
   - Correct behavior is guaranteed only for top-level windows *(A top-level window is a window that is not a child window, or has no parent window (which is the same as having the "desktop window" as a parent))*
   - X11: library relies on EWHM, more specifically `_NET_ACTIVE_WINDOW`, `_NET_WM_STATE_FULLSCREEN`, `_NET_WM_NAME`
+  - KDE Plasma on Wayland: the overlay window itself still runs on XWayland (Electron's
+    default), but the *target* window is found/tracked through KWin's D-Bus scripting
+    API (`org.kde.KWin`) instead of X11/EWMH, so target apps that have no XWayland
+    window at all (native-Wayland GTK4/Qt6 apps, Wine/Proton games using the Wayland
+    driver, etc.) can be attached to. This only applies when running under a KDE Plasma
+    Wayland session (detected via `WAYLAND_DISPLAY` + a live `org.kde.KWin` D-Bus name);
+    plain X11 sessions are unaffected. Requires `dbus-1` development headers and
+    `pkg-config` at build time on Linux, in addition to `libxcb`.
 
 Supported backends:
   - Windows (7 - 10)
-  - Linux (X11)
+  - Linux (X11, and target-window tracking on KDE Plasma Wayland sessions)
 
 Recommended dev utils
 - Windows: AccEvent (accevent.exe) and Inspect Object (inspect.exe) from Windows SDK

--- a/README.md
+++ b/README.md
@@ -17,14 +17,25 @@ Important notes:
   - Found target window remains "valid" even if its title has changed
   - Correct behavior is guaranteed only for top-level windows *(A top-level window is a window that is not a child window, or has no parent window (which is the same as having the "desktop window" as a parent))*
   - X11: library relies on EWHM, more specifically `_NET_ACTIVE_WINDOW`, `_NET_WM_STATE_FULLSCREEN`, `_NET_WM_NAME`
-  - KDE Plasma on Wayland: the overlay window itself still runs on XWayland (Electron's
-    default), but the *target* window is found/tracked through KWin's D-Bus scripting
-    API (`org.kde.KWin`) instead of X11/EWMH, so target apps that have no XWayland
-    window at all (native-Wayland GTK4/Qt6 apps, Wine/Proton games using the Wayland
-    driver, etc.) can be attached to. This only applies when running under a KDE Plasma
-    Wayland session (detected via `WAYLAND_DISPLAY` + a live `org.kde.KWin` D-Bus name);
-    plain X11 sessions are unaffected. Requires `dbus-1` development headers and
-    `pkg-config` at build time on Linux, in addition to `libxcb`.
+  - Linux/Wayland: this library only supports positioning/tracking the overlay window
+    itself via X11 (including XWayland) - Wayland gives clients no way to set their own
+    absolute window position at all. Electron 38+ defaults to native Wayland rendering
+    when launched inside a Wayland session, which silently breaks overlay positioning.
+    **You must launch your app with the `--ozone-platform=x11` command-line flag** (or
+    `--ozone-platform-hint=x11`) on Wayland sessions to force XWayland for the overlay
+    window. This can't be done for you from inside the library: Electron's ozone
+    platform is selected during its native startup, before any JS runs, so calling
+    `app.commandLine.appendSwitch('ozone-platform', 'x11')` at import time is too late
+    and can crash the GPU process instead of fixing anything - it must be a real CLI
+    argument (or set in `ELECTRON_OZONE_PLATFORM_HINT` on Electron < 38).
+  - KDE Plasma on Wayland: with the overlay forced onto XWayland as above, the *target*
+    window is found/tracked through KWin's D-Bus scripting API (`org.kde.KWin`) instead
+    of X11/EWMH, so target apps that have no XWayland window at all (native-Wayland
+    GTK4/Qt6 apps, Wine/Proton games using the Wayland driver, etc.) can be attached to.
+    This only applies when running under a KDE Plasma Wayland session (detected via
+    `WAYLAND_DISPLAY` + a live `org.kde.KWin` D-Bus name); plain X11 sessions are
+    unaffected. Requires `dbus-1` development headers and `pkg-config` at build time on
+    Linux, in addition to `libxcb`.
 
 Supported backends:
   - Windows (7 - 10)

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,12 +29,13 @@
           ],
           'link_settings': {
             'libraries': [
-              '-lxcb', '-lpthread'
+              '-lxcb', '-lpthread', '<!@(pkg-config --libs dbus-1)'
             ]
           },
-          'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread'],
+          'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread', '<!@(pkg-config --cflags dbus-1)'],
       	  'sources': [
             'src/lib/x11.c',
+            'src/lib/kde_wayland.c',
           ]
         }],
         ['OS=="mac"', {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "install": "node-gyp-build",
+    "prepare": "tsc",
     "prebuild": "prebuildify --napi",
     "demo:electron": "node-gyp rebuild && npx tsc && electron dist/demo/electron-demo.js"
   },

--- a/src/demo/electron-demo.ts
+++ b/src/demo/electron-demo.ts
@@ -63,6 +63,9 @@ function createWindow () {
     case 'linux': title = 'Untitled * — Kate'; break
     case 'darwin': title = 'Untitled'; break
   }
+  // Override to test attaching to an arbitrary window without editing source,
+  // e.g. OVERLAY_TARGET_TITLE="some window title" npm run demo:electron
+  title = process.env.OVERLAY_TARGET_TITLE || title
   OverlayController.attachByTitle(window, title, { hasTitleBarOnMac: true })
 }
 

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -4,6 +4,9 @@
 #include <node_api.h>
 #include "napi_helpers.h"
 #include "overlay_window.h"
+#ifdef __linux__
+#include "kde_wayland.h"
+#endif
 
 static napi_threadsafe_function threadsafe_fn = NULL;
 static struct ow_window_bounds last_reported_bounds = {0, 0, 0, 0};
@@ -225,6 +228,9 @@ napi_value AddonScreenshot(napi_env env, napi_callback_info info) {
 void AddonCleanUp(void* arg) {
   // @TODO
   // UnhookWinEvent(win_event_hhook);
+#ifdef __linux__
+  ow_kde_wayland_cleanup();
+#endif
 }
 
 NAPI_MODULE_INIT() {

--- a/src/lib/kde_wayland.c
+++ b/src/lib/kde_wayland.c
@@ -27,7 +27,11 @@ static const char* TRACKER_SCRIPT_TEMPLATE =
   "    callDBus(SERVICE, PATH, IFACE, 'Event', parts.join('\\u001f'));\n"
   "  }\n"
   "  function geom(w) {\n"
-  "    var g = w.frameGeometry;\n"
+  // x11.c's get_content_bounds() queries the X11 client window itself, not
+  // the WM-decorated frame, so it excludes title bars/borders. Use
+  // clientGeometry (not frameGeometry) here to match that contract -
+  // otherwise the overlay ends up sized/offset by the window decoration.
+  "    var g = w.clientGeometry;\n"
   // KWin scripting reports geometry in logical/DIP pixels, but the X11
   // backend (get_content_bounds in x11.c) reports physical pixels, and
   // index.ts's screenToDipPoint conversion for Linux expects the latter.
@@ -42,7 +46,7 @@ static const char* TRACKER_SCRIPT_TEMPLATE =
   "    if (w.active) {\n"
   "      send(['focus', w.internalId, 0, 0, 0, 0, '0']);\n"
   "    }\n"
-  "    w.frameGeometryChanged.connect(function() {\n"
+  "    w.clientGeometryChanged.connect(function() {\n"
   "      if (current !== w) return;\n"
   "      var g2 = geom(w);\n"
   "      send(['moveresize', w.internalId, g2[0], g2[1], g2[2], g2[3], '0']);\n"

--- a/src/lib/kde_wayland.c
+++ b/src/lib/kde_wayland.c
@@ -1,0 +1,446 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <dbus/dbus.h>
+#include <uv.h>
+#include "overlay_window.h"
+#include "kde_wayland.h"
+
+#define TRACKER_IFACE "org.electron_overlay_window.Tracker"
+#define TRACKER_PATH "/Tracker"
+
+// A persistent KWin script that finds the target window by exact title
+// match (mirrors x11.c's strcmp semantics), then reports attach/focus/
+// blur/moveresize/fullscreen/detach as they happen via callDBus into the
+// service we host below. Fields are joined with  (unit separator) so
+// no escaping of numbers/ids is needed on either side.
+static const char* TRACKER_SCRIPT_TEMPLATE =
+  "(function() {\n"
+  "  var SERVICE = '%s';\n"
+  "  var PATH = '" TRACKER_PATH "';\n"
+  "  var IFACE = '" TRACKER_IFACE "';\n"
+  "  var TARGET_TITLE = '%s';\n"
+  "  var current = null;\n"
+  "  function send(parts) {\n"
+  "    callDBus(SERVICE, PATH, IFACE, 'Event', parts.join('\\u001f'));\n"
+  "  }\n"
+  "  function geom(w) {\n"
+  "    var g = w.frameGeometry;\n"
+  // KWin scripting reports geometry in logical/DIP pixels, but the X11
+  // backend (get_content_bounds in x11.c) reports physical pixels, and
+  // index.ts's screenToDipPoint conversion for Linux expects the latter.
+  // Scale by the window's output devicePixelRatio to match that contract.
+  "    var s = (w.output && w.output.devicePixelRatio) ? w.output.devicePixelRatio : 1;\n"
+  "    return [Math.round(g.x * s), Math.round(g.y * s), Math.round(g.width * s), Math.round(g.height * s)];\n"
+  "  }\n"
+  "  function attach(w) {\n"
+  "    current = w;\n"
+  "    var g = geom(w);\n"
+  "    send(['attach', w.internalId, g[0], g[1], g[2], g[3], w.fullScreen ? '1' : '0']);\n"
+  "    if (w.active) {\n"
+  "      send(['focus', w.internalId, 0, 0, 0, 0, '0']);\n"
+  "    }\n"
+  "    w.frameGeometryChanged.connect(function() {\n"
+  "      if (current !== w) return;\n"
+  "      var g2 = geom(w);\n"
+  "      send(['moveresize', w.internalId, g2[0], g2[1], g2[2], g2[3], '0']);\n"
+  "    });\n"
+  "    w.fullScreenChanged.connect(function() {\n"
+  "      if (current !== w) return;\n"
+  "      send(['fullscreen', w.internalId, 0, 0, 0, 0, w.fullScreen ? '1' : '0']);\n"
+  "    });\n"
+  "    w.activeChanged.connect(function() {\n"
+  "      if (current !== w) return;\n"
+  "      send([w.active ? 'focus' : 'blur', w.internalId, 0, 0, 0, 0, '0']);\n"
+  "    });\n"
+  "    w.closed.connect(function() {\n"
+  "      if (current === w) {\n"
+  "        current = null;\n"
+  "        send(['detach', w.internalId, 0, 0, 0, 0, '0']);\n"
+  "      }\n"
+  "    });\n"
+  "  }\n"
+  "  function isMatch(w) {\n"
+  "    return w.caption === TARGET_TITLE;\n"
+  "  }\n"
+  "  var wins = workspace.windowList();\n"
+  "  for (var i = 0; i < wins.length; i++) {\n"
+  "    if (isMatch(wins[i])) { attach(wins[i]); break; }\n"
+  "  }\n"
+  "  workspace.windowAdded.connect(function(w) {\n"
+  "    if (current === null && isMatch(w)) attach(w);\n"
+  "  });\n"
+  "})();\n";
+
+// One-shot script generated on demand to activate the target window by id.
+static const char* ACTIVATE_SCRIPT_TEMPLATE =
+  "(function() {\n"
+  "  var id = '%s';\n"
+  "  var wins = workspace.windowList();\n"
+  "  for (var i = 0; i < wins.length; i++) {\n"
+  "    if (wins[i].internalId === id) { workspace.activeWindow = wins[i]; break; }\n"
+  "  }\n"
+  "})();\n";
+
+static DBusConnection* g_conn = NULL;
+static uv_mutex_t g_id_mutex;
+static char g_last_internal_id[128] = {0};
+static char g_plugin_name[64] = {0};
+
+static void escape_js_string(const char* in, char* out, size_t out_size) {
+  size_t j = 0;
+  for (size_t i = 0; in[i] != '\0' && j + 2 < out_size; i++) {
+    char c = in[i];
+    if (c == '\\' || c == '\'') {
+      out[j++] = '\\';
+      out[j++] = c;
+    } else if (c == '\n') {
+      out[j++] = '\\';
+      out[j++] = 'n';
+    } else {
+      out[j++] = c;
+    }
+  }
+  out[j] = '\0';
+}
+
+static bool write_temp_script(const char* content, char* out_path, size_t out_path_size) {
+  const char* runtime_dir = getenv("XDG_RUNTIME_DIR");
+  if (runtime_dir == NULL) {
+    runtime_dir = "/tmp";
+  }
+  snprintf(out_path, out_path_size, "%s/electron-overlay-window-XXXXXX.js", runtime_dir);
+  int fd = mkstemps(out_path, 3);
+  if (fd < 0) {
+    return false;
+  }
+  FILE* f = fdopen(fd, "w");
+  if (f == NULL) {
+    close(fd);
+    return false;
+  }
+  fputs(content, f);
+  fclose(f);
+  return true;
+}
+
+static bool call_load_script(DBusConnection* conn, const char* file_path, const char* plugin_name, int32_t* out_id) {
+  DBusMessage* msg = dbus_message_new_method_call("org.kde.KWin", "/Scripting", "org.kde.kwin.Scripting", "loadScript");
+  dbus_message_append_args(msg, DBUS_TYPE_STRING, &file_path, DBUS_TYPE_STRING, &plugin_name, DBUS_TYPE_INVALID);
+
+  DBusError err;
+  dbus_error_init(&err);
+  DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 2000, &err);
+  dbus_message_unref(msg);
+  if (reply == NULL) {
+    dbus_error_free(&err);
+    return false;
+  }
+
+  int32_t id = -1;
+  bool ok = dbus_message_get_args(reply, &err, DBUS_TYPE_INT32, &id, DBUS_TYPE_INVALID);
+  dbus_message_unref(reply);
+  dbus_error_free(&err);
+
+  if (ok && out_id != NULL) {
+    *out_id = id;
+  }
+  return ok;
+}
+
+static bool call_script_run(DBusConnection* conn, int32_t script_id) {
+  char path[64];
+  snprintf(path, sizeof(path), "/Scripting/Script%d", script_id);
+
+  DBusMessage* msg = dbus_message_new_method_call("org.kde.KWin", path, "org.kde.kwin.Script", "run");
+  DBusError err;
+  dbus_error_init(&err);
+  DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 2000, &err);
+  dbus_message_unref(msg);
+  bool ok = reply != NULL;
+  if (reply != NULL) {
+    dbus_message_unref(reply);
+  }
+  dbus_error_free(&err);
+  return ok;
+}
+
+static void call_unload_script(DBusConnection* conn, const char* plugin_name) {
+  DBusMessage* msg = dbus_message_new_method_call("org.kde.KWin", "/Scripting", "org.kde.kwin.Scripting", "unloadScript");
+  dbus_message_append_args(msg, DBUS_TYPE_STRING, &plugin_name, DBUS_TYPE_INVALID);
+  DBusError err;
+  dbus_error_init(&err);
+  DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 2000, &err);
+  dbus_message_unref(msg);
+  if (reply != NULL) {
+    dbus_message_unref(reply);
+  }
+  dbus_error_free(&err);
+}
+
+static void load_and_run_script(DBusConnection* conn, const char* content, const char* plugin_name, bool unload_after) {
+  char script_path[256];
+  if (!write_temp_script(content, script_path, sizeof(script_path))) {
+    fprintf(stderr, "electron-overlay-window: failed to write temp KWin script\n");
+    return;
+  }
+
+  int32_t script_id;
+  if (call_load_script(conn, script_path, plugin_name, &script_id)) {
+    call_script_run(conn, script_id);
+    if (unload_after) {
+      call_unload_script(conn, plugin_name);
+    }
+  } else {
+    fprintf(stderr, "electron-overlay-window: failed to load KWin script\n");
+  }
+
+  unlink(script_path);
+}
+
+static void handle_event_payload(const char* payload) {
+  char buf[512];
+  strncpy(buf, payload, sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
+
+  char* type = strtok(buf, "\x1f");
+  char* id = strtok(NULL, "\x1f");
+  char* xs = strtok(NULL, "\x1f");
+  char* ys = strtok(NULL, "\x1f");
+  char* ws = strtok(NULL, "\x1f");
+  char* hs = strtok(NULL, "\x1f");
+  char* fs = strtok(NULL, "\x1f");
+  if (type == NULL) {
+    return;
+  }
+
+  int32_t x = xs != NULL ? atoi(xs) : 0;
+  int32_t y = ys != NULL ? atoi(ys) : 0;
+  uint32_t width = ws != NULL ? (uint32_t)atoi(ws) : 0;
+  uint32_t height = hs != NULL ? (uint32_t)atoi(hs) : 0;
+  bool is_fullscreen = fs != NULL && fs[0] == '1';
+
+  if (id != NULL) {
+    uv_mutex_lock(&g_id_mutex);
+    strncpy(g_last_internal_id, id, sizeof(g_last_internal_id) - 1);
+    g_last_internal_id[sizeof(g_last_internal_id) - 1] = '\0';
+    uv_mutex_unlock(&g_id_mutex);
+  }
+
+  struct ow_event e;
+  memset(&e, 0, sizeof(e));
+
+  if (strcmp(type, "attach") == 0) {
+    e.type = OW_ATTACH;
+    e.data.attach.has_access = -1;
+    e.data.attach.is_fullscreen = is_fullscreen ? 1 : 0;
+    e.data.attach.bounds.x = x;
+    e.data.attach.bounds.y = y;
+    e.data.attach.bounds.width = width;
+    e.data.attach.bounds.height = height;
+    ow_emit_event(&e);
+  } else if (strcmp(type, "focus") == 0) {
+    e.type = OW_FOCUS;
+    ow_emit_event(&e);
+  } else if (strcmp(type, "blur") == 0) {
+    e.type = OW_BLUR;
+    ow_emit_event(&e);
+  } else if (strcmp(type, "detach") == 0) {
+    e.type = OW_DETACH;
+    ow_emit_event(&e);
+  } else if (strcmp(type, "moveresize") == 0) {
+    e.type = OW_MOVERESIZE;
+    e.data.moveresize.bounds.x = x;
+    e.data.moveresize.bounds.y = y;
+    e.data.moveresize.bounds.width = width;
+    e.data.moveresize.bounds.height = height;
+    ow_emit_event(&e);
+  } else if (strcmp(type, "fullscreen") == 0) {
+    e.type = OW_FULLSCREEN;
+    e.data.fullscreen.is_fullscreen = is_fullscreen;
+    ow_emit_event(&e);
+  }
+}
+
+static DBusHandlerResult tracker_message_handler(DBusConnection* connection, DBusMessage* message, void* user_data) {
+  (void)user_data;
+
+  if (dbus_message_is_method_call(message, TRACKER_IFACE, "Event")) {
+    const char* payload = NULL;
+    DBusError err;
+    dbus_error_init(&err);
+    if (dbus_message_get_args(message, &err, DBUS_TYPE_STRING, &payload, DBUS_TYPE_INVALID)) {
+      handle_event_payload(payload);
+    }
+    dbus_error_free(&err);
+
+    DBusMessage* reply = dbus_message_new_method_return(message);
+    if (reply != NULL) {
+      dbus_connection_send(connection, reply, NULL);
+      dbus_message_unref(reply);
+    }
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  if (dbus_message_is_method_call(message, "org.freedesktop.DBus.Introspectable", "Introspect")) {
+    const char* xml =
+      "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"\n"
+      "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
+      "<node><interface name=\"" TRACKER_IFACE "\">"
+      "<method name=\"Event\"><arg type=\"s\" direction=\"in\"/></method>"
+      "</interface></node>";
+    DBusMessage* reply = dbus_message_new_method_return(message);
+    if (reply != NULL) {
+      dbus_message_append_args(reply, DBUS_TYPE_STRING, &xml, DBUS_TYPE_INVALID);
+      dbus_connection_send(connection, reply, NULL);
+      dbus_message_unref(reply);
+    }
+    return DBUS_HANDLER_RESULT_HANDLED;
+  }
+
+  return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+static const DBusObjectPathVTable tracker_vtable = {
+  .unregister_function = NULL,
+  .message_function = tracker_message_handler,
+};
+
+static void hook_thread(void* arg) {
+  char* target_window_title = (char*)arg;
+
+  DBusError err;
+  dbus_error_init(&err);
+  g_conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+  if (g_conn == NULL) {
+    fprintf(stderr, "electron-overlay-window: failed to connect to session bus: %s\n", err.message);
+    dbus_error_free(&err);
+    free(target_window_title);
+    return;
+  }
+  dbus_error_free(&err);
+
+  int pid = (int)getpid();
+  char service_name[64];
+  snprintf(service_name, sizeof(service_name), "org.electron_overlay_window.Tracker%d", pid);
+  snprintf(g_plugin_name, sizeof(g_plugin_name), "electron-overlay-window-%d", pid);
+
+  dbus_error_init(&err);
+  int name_result = dbus_bus_request_name(g_conn, service_name, DBUS_NAME_FLAG_DO_NOT_QUEUE, &err);
+  if (name_result != DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER) {
+    fprintf(stderr, "electron-overlay-window: failed to acquire D-Bus name %s\n", service_name);
+    dbus_error_free(&err);
+    free(target_window_title);
+    return;
+  }
+  dbus_error_free(&err);
+
+  dbus_connection_register_object_path(g_conn, TRACKER_PATH, &tracker_vtable, NULL);
+
+  char escaped_title[600];
+  escape_js_string(target_window_title, escaped_title, sizeof(escaped_title));
+
+  char script[8192];
+  snprintf(script, sizeof(script), TRACKER_SCRIPT_TEMPLATE, service_name, escaped_title);
+
+  load_and_run_script(g_conn, script, g_plugin_name, /* unload_after */ false);
+
+  free(target_window_title);
+
+  while (dbus_connection_read_write_dispatch(g_conn, -1)) {
+    // keep dispatching Event calls from the KWin script
+  }
+}
+
+bool ow_kde_wayland_is_available(void) {
+  if (getenv("WAYLAND_DISPLAY") == NULL) {
+    return false;
+  }
+
+  // The tracking hook thread blocks indefinitely in
+  // dbus_connection_read_write_dispatch() on the same DBusConnection that
+  // ow_kde_wayland_focus_target() later uses (from the Node.js thread) to
+  // make blocking calls. libdbus only supports that concurrent use once
+  // its internal locking is enabled; safe/idempotent to call repeatedly.
+  dbus_threads_init_default();
+
+  DBusError err;
+  dbus_error_init(&err);
+  DBusConnection* conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+  if (conn == NULL) {
+    dbus_error_free(&err);
+    return false;
+  }
+
+  dbus_bool_t has_owner = dbus_bus_name_has_owner(conn, "org.kde.KWin", &err);
+  dbus_error_free(&err);
+  dbus_connection_unref(conn);
+  return has_owner;
+}
+
+void ow_kde_wayland_start_hook(const char* target_window_title) {
+  uv_mutex_init(&g_id_mutex);
+  char* title_copy = strdup(target_window_title);
+  uv_thread_create(&hook_tid, hook_thread, title_copy);
+}
+
+// The hook thread blocks forever in dbus_connection_read_write_dispatch()
+// on `g_conn`. These two entry points are called from the Node.js thread,
+// so each opens its own short-lived private connection instead of racing
+// the hook thread over `g_conn` (libdbus does not support a blocking call
+// on one thread and an indefinite read/dispatch loop on another thread
+// sharing the same connection).
+static DBusConnection* open_private_session_conn(void) {
+  DBusError err;
+  dbus_error_init(&err);
+  DBusConnection* conn = dbus_bus_get_private(DBUS_BUS_SESSION, &err);
+  dbus_error_free(&err);
+  return conn;
+}
+
+static void close_private_conn(DBusConnection* conn) {
+  dbus_connection_close(conn);
+  dbus_connection_unref(conn);
+}
+
+void ow_kde_wayland_focus_target(void) {
+  char id_copy[128];
+  uv_mutex_lock(&g_id_mutex);
+  strncpy(id_copy, g_last_internal_id, sizeof(id_copy) - 1);
+  id_copy[sizeof(id_copy) - 1] = '\0';
+  uv_mutex_unlock(&g_id_mutex);
+
+  if (id_copy[0] == '\0') {
+    return;
+  }
+
+  char escaped_id[160];
+  escape_js_string(id_copy, escaped_id, sizeof(escaped_id));
+
+  char script[512];
+  snprintf(script, sizeof(script), ACTIVATE_SCRIPT_TEMPLATE, escaped_id);
+
+  char plugin_name[64];
+  snprintf(plugin_name, sizeof(plugin_name), "electron-overlay-window-activate-%d", (int)getpid());
+
+  DBusConnection* conn = open_private_session_conn();
+  if (conn == NULL) {
+    return;
+  }
+  load_and_run_script(conn, script, plugin_name, /* unload_after */ true);
+  close_private_conn(conn);
+}
+
+void ow_kde_wayland_cleanup(void) {
+  if (g_plugin_name[0] == '\0') {
+    return;
+  }
+  DBusConnection* conn = open_private_session_conn();
+  if (conn == NULL) {
+    return;
+  }
+  call_unload_script(conn, g_plugin_name);
+  close_private_conn(conn);
+}

--- a/src/lib/kde_wayland.h
+++ b/src/lib/kde_wayland.h
@@ -1,0 +1,30 @@
+#ifndef ADDON_SRC_KDE_WAYLAND_H_
+#define ADDON_SRC_KDE_WAYLAND_H_
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// True only when running under a KDE Plasma Wayland session where the
+// KWin scripting D-Bus API (org.kde.KWin /Scripting) is reachable.
+bool ow_kde_wayland_is_available(void);
+
+// Starts a background thread that loads a persistent KWin script to find
+// and track the target window (by title) via workspace signals, forwarding
+// ow_event's the same way the X11 backend does.
+void ow_kde_wayland_start_hook(const char* target_window_title);
+
+// Activates/focuses the currently tracked target window, using the last
+// internalId reported by the tracking script.
+void ow_kde_wayland_focus_target(void);
+
+// Best-effort cleanup of the loaded KWin script.
+void ow_kde_wayland_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !ADDON_SRC_KDE_WAYLAND_H_

--- a/src/lib/x11.c
+++ b/src/lib/x11.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <xcb/xcb.h>
 #include "overlay_window.h"
+#include "kde_wayland.h"
 
 static xcb_connection_t* x_conn;
 static xcb_window_t root;
@@ -40,6 +41,12 @@ static struct ow_target_window target_info = {
 static struct ow_overlay_window overlay_info = {
   .window_id = XCB_WINDOW_NONE
 };
+
+// When true, the target window is found/tracked/focused through the KDE
+// Wayland (KWin scripting) backend instead of X11 EWMH polling below. The
+// overlay window itself always stays on XWayland, so `x_conn` is still set
+// up and used for `ow_activate_overlay()` in both modes.
+static bool using_kde_wayland_backend = false;
 
 static xcb_window_t get_active_window() {
   xcb_get_property_reply_t* prop_reply = xcb_get_property_reply(x_conn, xcb_get_property(x_conn, 0, root, ATOM_NET_ACTIVE_WINDOW, XCB_ATOM_WINDOW, 0, 1), NULL);
@@ -283,6 +290,16 @@ static void hook_thread(void* _arg) {
     uint32_t values[] = {1};
     xcb_change_window_attributes(x_conn, overlay_info.window_id, XCB_CW_OVERRIDE_REDIRECT, values);
   }
+  xcb_flush(x_conn);
+
+  if (using_kde_wayland_backend) {
+    // Target discovery/tracking/focusing is handled by the KDE Wayland
+    // backend instead (it can see native-Wayland windows that have no
+    // XWayland-backed X11 window at all). `x_conn` stays open and is
+    // still used by `ow_activate_overlay()`.
+    ow_kde_wayland_start_hook(target_info.title);
+    return;
+  }
 
   // listen for `_NET_ACTIVE_WINDOW` changes
   uint32_t mask[] = { XCB_EVENT_MASK_PROPERTY_CHANGE };
@@ -311,6 +328,7 @@ void ow_start_hook(char* target_window_title, void* overlay_window_id) {
   if (overlay_window_id != NULL) {
     overlay_info.window_id = *((xcb_window_t*)overlay_window_id);
   }
+  using_kde_wayland_backend = ow_kde_wayland_is_available();
   uv_thread_create(&hook_tid, hook_thread, NULL);
 }
 
@@ -320,6 +338,10 @@ void ow_activate_overlay() {
 }
 
 void ow_focus_target() {
+  if (using_kde_wayland_backend) {
+    ow_kde_wayland_focus_target();
+    return;
+  }
   xcb_set_input_focus(x_conn, XCB_INPUT_FOCUS_PARENT, target_info.window_id, XCB_CURRENT_TIME);
   xcb_flush(x_conn);
 }


### PR DESCRIPTION
Native-Wayland target windows (no XWayland fallback) are invisible to the existing X11/EWMH-based tracking, since core Wayland gives clients no way to enumerate other windows, geometry, or focus. On KDE Plasma, KWin's scripting D-Bus API (org.kde.KWin /Scripting) fills that gap: a persistent script loaded through it can see workspace.windowList() uniformly across X11 and native-Wayland windows and report attach/focus/blur/moveresize/ fullscreen/detach back to a D-Bus service the addon hosts.

The overlay window itself still runs on XWayland (Electron's default) and keeps using the existing xcb code for its own activation; only target discovery/tracking/focusing is delegated to the new backend, and only when a KDE Plasma Wayland session is actually detected. Plain X11 sessions are unaffected.